### PR TITLE
Starts docs and exercises, implement verify-exercises

### DIFF
--- a/bin/verify-exercises
+++ b/bin/verify-exercises
@@ -23,11 +23,21 @@
 
 slug="${1:-*}"
 
+test_example() {
+    MODULE_FILE=`jq -r '.files.solution[]' $1/.meta/config.json`
+    EXAMPLE_FILE=`jq -r '.files.example[]' $1/.meta/config.json`
+    TEST_FILE=`jq -r '.files.test[]' $1/.meta/config.json`
+    mv "$1/${MODULE_FILE}" "$1/${MODULE_FILE}.bak"
+    cp "$1/${EXAMPLE_FILE}" "$1/${MODULE_FILE}"
+    roc test "$1/${TEST_FILE}"
+    mv -f "$1/${MODULE_FILE}".bak "$1/${MODULE_FILE}"
+}
+
 # Verify the Concept Exercises
 for concept_exercise_dir in ./exercises/concept/${slug}/; do
     if [ -d $concept_exercise_dir ]; then
         echo "Checking $(basename "${concept_exercise_dir}") exercise..."
-        # TODO: run command to verify that the exemplar solution passes the tests
+        test_example "${concept_exercise_dir%/}"
     fi
 done
 
@@ -35,6 +45,6 @@ done
 for practice_exercise_dir in ./exercises/practice/${slug}/; do
     if [ -d $practice_exercise_dir ]; then
         echo "Checking $(basename "${practice_exercise_dir}") exercise..."
-        # TODO: run command to verify that the example solution passes the tests
+        test_example "${practice_exercise_dir%/}"
     fi
 done

--- a/config.json
+++ b/config.json
@@ -46,6 +46,38 @@
       }
     ]
   },
+  "key_features": [
+    {
+      "title": "Fast",
+      "content": "Roc code is designed to build fast and run fast. It compiles to machine code or WebAssembly.",
+      "icon": "fast"
+    },
+    {
+      "title": "Functional",
+      "content": "Roc has a small number of simple language primitives. It's a single-paradigm functional language.",
+      "icon": "functional"
+    },
+    {
+      "title": "Friendly",
+      "content": "Roc's syntax, semantics, and included toolset all prioritize user-friendliness.",
+      "icon": "extensible"
+    },
+    {
+      "title": "Safe",
+      "content": "Roc's powerful type system and immutability lead to more predictable and maintainable code.",
+      "icon": "immutable"
+    },
+    {
+      "title": "Interoperable",
+      "content": "Roc is works well with other languages, making it easier to integrate into existing projects.",
+      "icon": "interop"
+    },
+    {
+      "title": "Evolving",
+      "content": "Roc is a young language, and it is evolving fast.",
+      "icon": "evolving"
+    }
+  ],
   "tags": [
     "execution_mode/compiled",
     "paradigm/functional",

--- a/config.json
+++ b/config.json
@@ -8,23 +8,58 @@
     "representer": false,
     "analyzer": false
   },
-  "blurb": "TODO: add blurb",
+  "blurb": "Roc is a fast, friendly, functional language.",
   "version": 3,
   "online_editor": {
     "indent_style": "space",
-    "indent_size": 4
+    "indent_size": 4,
+    "highlightjs_language": "roc"
   },
   "files": {
-    "solution": [],
-    "test": [],
-    "example": [],
-    "exemplar": []
+    "solution": [
+      "%{pascal_slug}.roc"
+    ],
+    "test": [
+      "%{kebab_slug}-test.roc"
+    ],
+    "example": [
+      ".meta/Example.roc"
+    ]
   },
   "exercises": {
-    "concept": [],
-    "practice": []
+    "practice": [
+      {
+        "slug": "hello-world",
+        "name": "Hello World",
+        "uuid": "c2e68f17-4f90-4510-a945-9e2dbf23d777",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1
+      },
+      {
+        "slug": "leap",
+        "name": "Leap",
+        "uuid": "fd8452d6-b1af-424a-9d03-aadb4945e644",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1
+      }
+    ]
   },
-  "concepts": [],
-  "key_features": [],
-  "tags": []
+  "tags": [
+    "execution_mode/compiled",
+    "paradigm/functional",
+    "platform/linux",
+    "platform/mac",
+    "platform/windows",
+    "typing/strong",
+    "used_for/artificial_intelligence",
+    "used_for/backends",
+    "used_for/cross_platform_development",
+    "used_for/embedded_systems",
+    "used_for/games",
+    "used_for/robotics",
+    "used_for/scientific_calculations",
+    "used_for/scripts"
+  ]
 }

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,14 +1,13 @@
 # About
 
-<!-- TODO: write document
+Roc is a modern, fast, and safe programming language designed for building reliable software with simplicity in mind. With an emphasis on performance and minimalism, Roc brings a fresh perspective to the world of functional programming, aiming to make it accessible and efficient for developers.
 
-  This document contains a short introduction to the language.
+## Main Features
 
-  The introduction should be relatively brief and touch upon what
-  makes the language interesting (and possibly unique). The goal
-  is to help students decide if they want to join this track.
+- **Simplicity and Safety**: Roc is designed to reduce common programming errors through its type system and by enforcing immutability by default, which leads to more predictable and maintainable code.
+- **Optimized Performance**: Roc's compiler is built to generate highly optimized machine code, ensuring that applications run fast and efficiently.
+- **No Nonsense Dependencies**: Roc encourages simplicity not just in code, but also in dependency management, aiming for minimal external dependencies.
+- **Clean Syntax**: Roc's syntax is straightforward and easy to read, drawing inspiration from modern functional languages while stripping away unnecessary complexity.
+- **Interoperability**: Roc is built to work well with other languages, making it easier to integrate into existing projects.
 
-  The contents of this document are displayed on the track page,
-  provided the student has not joined the track.
-
-  See https://exercism.org/docs/building/tracks/docs for more information. -->
+For more details, visit [roc-lang.org](https://roc-lang.org).

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,3 @@
 # Installation
 
-To install Roc, please follow the instructions at [roc-lang.org/install](https://roc-lang.org/install).
+To install Roc, please follow the instructions at [roc-lang.org/install](https://roc-lang.org/install). You only need to install Roc, and optionally the editor Extensions/Plugins of your choice, you don't need to install Rust or Zig (which are used to build Roc itself).

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,15 +1,3 @@
 # Installation
 
-<!-- TODO: write document
-
-  This document should describe what the student needs to install
-  to allow working on the track on their local system using the CLI.
-
-  You can include the installation instructions in this document, but
-  usually it is better to link to a resource with the official installation
-  instructions, to prevent the instructions from becoming outdated.
-
-  The contents of this document are displayed on the track's documentation
-  page at `https://exercism.org/docs/tracks/<track>/installation`.
-
-  See https://exercism.org/docs/building/tracks/docs for more information. -->
+To install Roc, please follow the instructions at [roc-lang.org/install](https://roc-lang.org/install).

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,4 @@
 # Installation
 
-To install Roc, please follow the instructions at [roc-lang.org/install](https://roc-lang.org/install). You only need to install Roc, and optionally the editor Extensions/Plugins of your choice, you don't need to install Rust or Zig (which are used to build Roc itself).
+To install Roc, please follow the instructions at [roc-lang.org/install](https://roc-lang.org/install).
+You only need to install Roc, and optionally the editor Extensions/Plugins of your choice, you don't need to install Rust or Zig (which are used to build Roc itself).

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,13 +1,7 @@
 # Learning
 
-<!-- TODO: write document
+- The [Roc tutorial](https://www.roc-lang.org/tutorial) is a good place to start.
+- You can then go through the [code examples](https://www.roc-lang.org/examples).
+- Then you will want to get your hands dirty! Go through the Exercism practice exercises in this Roc track.
 
-  This document should link to learning resources.
-
-  Feel free to link to any good learning resources you know, whether they
-  be websites, blogs, books, videos or courses.
-
-  The contents of this document are displayed on the track's documentation
-  page at `https://exercism.org/docs/tracks/<track>/learning`.
-
-  See https://exercism.org/docs/building/tracks/docs for more information. -->
+Have fun learning Roc!

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -2,6 +2,5 @@
 
 - The [Roc tutorial](https://www.roc-lang.org/tutorial) is a good place to start.
 - You can then go through the [code examples](https://www.roc-lang.org/examples).
-- Then you will want to get your hands dirty! Go through the Exercism practice exercises in this Roc track.
 
 Have fun learning Roc!

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,13 +1,6 @@
 # Resources
 
-<!-- TODO: write document
-
-  This document should link to useful resources.
-
-  Feel free to link to any good resources you know, whether they
-  be websites, videos, mailing lists, etc.
-
-  The contents of this document are displayed on the track's documentation
-  page at `https://exercism.org/docs/tracks/<track>/resources`.
-
-  See https://exercism.org/docs/building/tracks/docs for more information. -->
+- Official website: https://www.roc-lang.org/
+- Code examples: https://www.roc-lang.org/examples
+- Community: https://www.roc-lang.org/community
+- Github: https://github.com/roc-lang/roc/

--- a/docs/SNIPPET.txt
+++ b/docs/SNIPPET.txt
@@ -1,17 +1,13 @@
+app [main] { pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.12.0/Lb8EgiejTUzbggO2HVVuPJFkwvvsfW6LojkLR20kTVE.tar.br" }
+
+import pf.Stdout
+
+factorial = \n ->
+    if n == 1 then
+        1
+    else
+        n * factorial (n - 1)
+
 main =
-    Path.fromStr "url.txt"
-    |> storeEmail
-    |> Task.onErr handleErr
-
-storeEmail = \path ->
-    url = File.readUtf8! path
-    user = Http.get! url Json.utf8
-    dest = Path.fromStr "$(user.name).txt"
-    File.writeUtf8! dest user.email
-    Stdout.line! "Wrote email to $(Path.display dest)"
-
-handleErr = \err ->
-    when err is
-        HttpErr url _ -> Stderr.line! "Error fetching URL $(url)"
-        FileReadErr path _ -> Stderr.line! "Error reading from $(Path.display path)"
-        FileWriteErr path _ -> Stderr.line! "Error writing to $(Path.display path)"
+    result = factorial 5
+    Stdout.line! "factorial 5 = 1 * 2 * 3 * 4 * 5 = $(Num.toStr result)"

--- a/docs/SNIPPET.txt
+++ b/docs/SNIPPET.txt
@@ -1,1 +1,17 @@
-TODO: add snippet
+main =
+    Path.fromStr "url.txt"
+    |> storeEmail
+    |> Task.onErr handleErr
+
+storeEmail = \path ->
+    url = File.readUtf8! path
+    user = Http.get! url Json.utf8
+    dest = Path.fromStr "$(user.name).txt"
+    File.writeUtf8! dest user.email
+    Stdout.line! "Wrote email to $(Path.display dest)"
+
+handleErr = \err ->
+    when err is
+        HttpErr url _ -> Stderr.line! "Error fetching URL $(url)"
+        FileReadErr path _ -> Stderr.line! "Error reading from $(Path.display path)"
+        FileWriteErr path _ -> Stderr.line! "Error writing to $(Path.display path)"

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,15 +1,5 @@
 # Tests
 
-<!-- TODO: write document
+Roc comes with its own integrated test tools, no need to install anything else.
 
-  This document should describe everything related to running tests in the track.
-
-  If your track uses skipped tests, this document can explain why thet is used and
-  how to unskip tests.
-
-  This document can also link to the testing framework documentation.
-
-  The contents of this document are displayed on the track's documentation
-  page at `https://exercism.org/docs/tracks/<track>/tests`.
-
-  See https://exercism.org/docs/building/tracks/docs for more information. -->
+To test your solution to an exercise, open a terminal, go to the exercise directory, run `roc test <exercise-name>-test.roc`, for example `roc test hello-world-test.roc`, and ensure that all the tests pass.

--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -1,0 +1,5 @@
+# Instructions append
+
+The file to edit is named `HelloWorld.roc`.
+
+If you are using the command line, run the test suite using `roc test hello-world-test.roc`

--- a/exercises/practice/hello-world/.docs/instructions.md
+++ b/exercises/practice/hello-world/.docs/instructions.md
@@ -1,0 +1,16 @@
+# Instructions
+
+The classical introductory exercise.
+Just say "Hello, World!".
+
+["Hello, World!"][hello-world] is the traditional first program for beginning programming in a new language or environment.
+
+The objectives are simple:
+
+- Modify the provided code so that it produces the string "Hello, World!".
+- Run the test suite and make sure that it succeeds.
+- Submit your solution and check it at the website.
+
+If everything goes well, you will be ready to fetch your first real exercise.
+
+[hello-world]: https://en.wikipedia.org/wiki/%22Hello,_world!%22_program

--- a/exercises/practice/hello-world/.meta/Example.roc
+++ b/exercises/practice/hello-world/.meta/Example.roc
@@ -1,0 +1,3 @@
+module [hello]
+
+hello = "Hello, World!"

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -1,0 +1,22 @@
+{
+  "authors": [
+    "ageron"
+  ],
+  "contributors": [
+    "keiravillekode"
+  ],
+  "files": {
+    "solution": [
+      "HelloWorld.roc"
+    ],
+    "test": [
+      "hello-world-test.roc"
+    ],
+    "example": [
+      ".meta/Example.roc"
+    ]
+  },
+  "blurb": "Exercism's classic introductory exercise. Just say \"Hello, World!\".",
+  "source": "This is an exercise to introduce users to using Exercism",
+  "source_url": "https://en.wikipedia.org/wiki/%22Hello,_world!%22_program"
+}

--- a/exercises/practice/hello-world/.meta/tests.toml
+++ b/exercises/practice/hello-world/.meta/tests.toml
@@ -1,0 +1,13 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[af9ffe10-dc13-42d8-a742-e7bdafac449d]
+description = "Say Hi!"

--- a/exercises/practice/hello-world/HelloWorld.roc
+++ b/exercises/practice/hello-world/HelloWorld.roc
@@ -1,0 +1,3 @@
+module [hello]
+
+hello = "Goodbye, Mars!"

--- a/exercises/practice/hello-world/hello-world-test.roc
+++ b/exercises/practice/hello-world/hello-world-test.roc
@@ -1,0 +1,9 @@
+app [main] { pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.12.0/Lb8EgiejTUzbggO2HVVuPJFkwvvsfW6LojkLR20kTVE.tar.br" }
+
+import pf.Task exposing [Task]
+import HelloWorld exposing [hello]
+
+expect hello == "Hello, World!"
+
+main =
+    Task.ok {}

--- a/exercises/practice/leap/.docs/instructions.md
+++ b/exercises/practice/leap/.docs/instructions.md
@@ -1,0 +1,3 @@
+# Instructions
+
+Your task is to determine whether a given year is a leap year.

--- a/exercises/practice/leap/.docs/introduction.md
+++ b/exercises/practice/leap/.docs/introduction.md
@@ -1,0 +1,16 @@
+# Introduction
+
+A leap year (in the Gregorian calendar) occurs:
+
+- In every year that is evenly divisible by 4.
+- Unless the year is evenly divisible by 100, in which case it's only a leap year if the year is also evenly divisible by 400.
+
+Some examples:
+
+- 1997 was not a leap year as it's not divisible by 4.
+- 1900 was not a leap year as it's not divisible by 400.
+- 2000 was a leap year!
+
+~~~~exercism/note
+For a delightful, four-minute explanation of the whole phenomenon of leap years, check out [this YouTube video](https://www.youtube.com/watch?v=xX96xng7sAE).
+~~~~

--- a/exercises/practice/leap/.meta/Example.roc
+++ b/exercises/practice/leap/.meta/Example.roc
@@ -1,0 +1,4 @@
+module [isLeapYear]
+
+isLeapYear = \year ->
+    (year % 4 == 0) && (year % 400 == 0 || year % 100 != 0)

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -1,0 +1,11 @@
+{
+  "authors": ["ageron"],
+  "files": {
+    "solution": ["Leap.roc"],
+    "test": ["leap-test.roc"],
+    "example": [".meta/Example.roc"]
+  },
+  "blurb": "Determine whether a given year is a leap year.",
+  "source": "CodeRanch Cattle Drive, Assignment 3",
+  "source_url": "https://coderanch.com/t/718816/Leap"
+}

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -1,9 +1,17 @@
 {
-  "authors": ["ageron"],
+  "authors": [
+    "ageron"
+  ],
   "files": {
-    "solution": ["Leap.roc"],
-    "test": ["leap-test.roc"],
-    "example": [".meta/Example.roc"]
+    "solution": [
+      "Leap.roc"
+    ],
+    "test": [
+      "leap-test.roc"
+    ],
+    "example": [
+      ".meta/Example.roc"
+    ]
   },
   "blurb": "Determine whether a given year is a leap year.",
   "source": "CodeRanch Cattle Drive, Assignment 3",

--- a/exercises/practice/leap/.meta/tests.toml
+++ b/exercises/practice/leap/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[6466b30d-519c-438e-935d-388224ab5223]
+description = "year not divisible by 4 in common year"
+
+[ac227e82-ee82-4a09-9eb6-4f84331ffdb0]
+description = "year divisible by 2, not divisible by 4 in common year"
+
+[4fe9b84c-8e65-489e-970b-856d60b8b78e]
+description = "year divisible by 4, not divisible by 100 in leap year"
+
+[7fc6aed7-e63c-48f5-ae05-5fe182f60a5d]
+description = "year divisible by 4 and 5 is still a leap year"
+
+[78a7848f-9667-4192-ae53-87b30c9a02dd]
+description = "year divisible by 100, not divisible by 400 in common year"
+
+[9d70f938-537c-40a6-ba19-f50739ce8bac]
+description = "year divisible by 100 but not by 3 is still not a leap year"
+
+[42ee56ad-d3e6-48f1-8e3f-c84078d916fc]
+description = "year divisible by 400 is leap year"
+
+[57902c77-6fe9-40de-8302-587b5c27121e]
+description = "year divisible by 400 but not by 125 is still a leap year"
+
+[c30331f6-f9f6-4881-ad38-8ca8c12520c1]
+description = "year divisible by 200, not divisible by 400 in common year"

--- a/exercises/practice/leap/Leap.roc
+++ b/exercises/practice/leap/Leap.roc
@@ -1,0 +1,4 @@
+module [isLeapYear]
+
+isLeapYear = \year ->
+    year > 0

--- a/exercises/practice/leap/leap-test.roc
+++ b/exercises/practice/leap/leap-test.roc
@@ -1,0 +1,26 @@
+app [main] { pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.12.0/Lb8EgiejTUzbggO2HVVuPJFkwvvsfW6LojkLR20kTVE.tar.br" }
+
+import pf.Task exposing [Task]
+import Leap exposing [isLeapYear]
+
+# year not divisible by 4 in common year
+expect !(isLeapYear 2015)
+# year divisible by 2, not divisible by 4 in common year
+expect !(isLeapYear 1970)
+# year divisible by 4, not divisible by 100 in leap year
+expect isLeapYear 1996
+# year divisible by 4 and 5 is still a leap year
+expect isLeapYear 1960
+# year divisible by 100, not divisible by 400 in common year
+expect !(isLeapYear 2100)
+# year divisible by 100 but not by 3 is still not a leap year
+expect !(isLeapYear 1900)
+# year divisible by 400 is leap year
+expect isLeapYear 2000
+# year divisible by 400 but not by 125 is still a leap year
+expect isLeapYear 2400
+# year divisible by 200, not divisible by 400 in common year
+expect !(isLeapYear 1800)
+
+main =
+    Task.ok {}

--- a/exercises/shared/.docs/help.md
+++ b/exercises/shared/.docs/help.md
@@ -1,21 +1,6 @@
 # Help
 
-<!-- TODO: write document
+[Roc Zulip Chat](https://roc.zulipchat.com/) is the most active community gathering place.
+We love it when new people stop by and introduce themselves in [`#introductions`](https://roc.zulipchat.com/#narrow/stream/387892-introductions) so others can welcome you to the community!
 
-  This document should contain track-specific instructions on how to get help when
-  the student is stuck.
-
-  The instructions should be short and to the point.
-
-  You could link to resources like Gitter channels, forums or mailing lists:
-  whatever can help a student become unstuck.
-
-  This document should **not** link to Exercism-wide (track-agnostic) help resources,
-  as those resources will automatically be included in the HELP.md file.
-
-  The links in this document can overlap with those in docs/LEARNING.md or docs/RESOURCES.md
-
-  When a student downloads an exercise via the CLI, this file's contents are
-  included into the HELP.md file.
-
-  See https://exercism.org/docs/building/tracks/shared-files for more information. -->
+Feel free to ask us questions, we'd be happy to help.

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -1,3 +1,42 @@
 # Testing on the Command Line
 
-To test your solution to an exercise, open a terminal, go to this exercise's directory, run `roc test <exercise-name>-test.roc`, for example `roc test hello-world-test.roc`, and ensure that all the tests pass.
+To download an exercise, for example `hello-world`, open a terminal and run:
+
+```bash
+exercism download --track roc --exercise hello-world
+```
+
+Then go to the exercise directory and edit the code to solve the exercise. For example:
+
+```bash
+cd {your Exercism folder}/roc/hello-world
+edit HelloWorld.roc
+```
+
+Each exercise comes with a test suite. You can run the tests using the `roc test` command, for example:
+
+```
+roc test hello-world-test.roc
+```
+
+If you've solved the exercise, you should see 0 failed test, for example:
+
+```
+0 failed and 1 passed in 583 ms.
+```
+
+However, if your code has any errors, they will look like this:
+
+```
+── EXPECT FAILED in hello-world-test.roc ───────────────────────────────────────
+
+This expectation failed:
+
+6│  expect hello == "Hello, World!"
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+1 failed and 0 passed in 1264 ms.
+```
+
+This should help you fix your code. Once your code works, you can submit it using the `exercism submit` command (see `HELP.md` in the exercise directory for more details).

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -1,15 +1,3 @@
-# Tests
+# Testing on the Command Line
 
-<!-- TODO: write document
-
-  This document should contain instructions on how to run the exercise's tests.
-
-  The instructions should be short and to the point.
-
-  The docs/TESTS.md file can contain a more verbose description on how to run tests.
-
-  When a student downloads an exercise via the CLI, this file's contents are
-  included into the HELP.md file.
-
-  See https://exercism.org/docs/building/tracks/shared-files for more information.
--->
+To test your solution to an exercise, open a terminal, go to this exercise's directory, run `roc test <exercise-name>-test.roc`, for example `roc test hello-world-test.roc`, and ensure that all the tests pass.


### PR DESCRIPTION
Add a first version of each documentation file.
Also add the first two practice exercises, hello-world and leap, including example code and tests.
Lastly, implement `verify-exercises` (all tests pass).
`configlet lint` and `configlet sync` are happy. 👍 
