### PR TITLE
Swap docs/TESTS.md with exercises/shared/.docs/tests.md

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,4 +1,4 @@
-# Testing on the Command Line
+# Tests
 
 To download an exercise, for example `hello-world`, open a terminal and run:
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,5 +1,42 @@
-# Tests
+# Testing on the Command Line
 
-Roc comes with its own integrated test tools, no need to install anything else.
+To download an exercise, for example `hello-world`, open a terminal and run:
 
-To test your solution to an exercise, open a terminal, go to the exercise directory, run `roc test <exercise-name>-test.roc`, for example `roc test hello-world-test.roc`, and ensure that all the tests pass.
+```bash
+exercism download --track roc --exercise hello-world
+```
+
+Then go to the exercise directory and edit the code to solve the exercise. For example:
+
+```bash
+cd {your Exercism folder}/roc/hello-world
+edit HelloWorld.roc
+```
+
+Each exercise comes with a test suite. You can run the tests using the `roc test` command, for example:
+
+```
+roc test hello-world-test.roc
+```
+
+If you've solved the exercise, you should see 0 failed test, for example:
+
+```
+0 failed and 1 passed in 583 ms.
+```
+
+However, if your code has any errors, they will look like this:
+
+```
+── EXPECT FAILED in hello-world-test.roc ───────────────────────────────────────
+
+This expectation failed:
+
+6│  expect hello == "Hello, World!"
+    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+
+1 failed and 0 passed in 1264 ms.
+```
+
+This should help you fix your code. Once your code works, you can submit it using the `exercism submit` command (see `HELP.md` in the exercise directory for more details).

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -1,4 +1,4 @@
-# Tests
+# Testing on the Command Line
 
 Roc comes with its own integrated test tools, no need to install anything else.
 

--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -1,42 +1,5 @@
-# Testing on the Command Line
+# Tests
 
-To download an exercise, for example `hello-world`, open a terminal and run:
+Roc comes with its own integrated test tools, no need to install anything else.
 
-```bash
-exercism download --track roc --exercise hello-world
-```
-
-Then go to the exercise directory and edit the code to solve the exercise. For example:
-
-```bash
-cd {your Exercism folder}/roc/hello-world
-edit HelloWorld.roc
-```
-
-Each exercise comes with a test suite. You can run the tests using the `roc test` command, for example:
-
-```
-roc test hello-world-test.roc
-```
-
-If you've solved the exercise, you should see 0 failed test, for example:
-
-```
-0 failed and 1 passed in 583 ms.
-```
-
-However, if your code has any errors, they will look like this:
-
-```
-── EXPECT FAILED in hello-world-test.roc ───────────────────────────────────────
-
-This expectation failed:
-
-6│  expect hello == "Hello, World!"
-    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-
-1 failed and 0 passed in 1264 ms.
-```
-
-This should help you fix your code. Once your code works, you can submit it using the `exercism submit` command (see `HELP.md` in the exercise directory for more details).
+To test your solution to an exercise, open a terminal, go to the exercise directory, run `roc test <exercise-name>-test.roc`, for example `roc test hello-world-test.roc`, and ensure that all the tests pass.


### PR DESCRIPTION
Swapping these files since `exercises/shared/.docs/tests.md` is intended as a quick guide to testing, whereas `docs/TESTS.md` goes into more detail.

Suggested by @ErikSchierboom here:
https://github.com/exercism/roc/pull/3#discussion_r1724459945_