### PR TITLE
Adapt Python generator to Roc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 .DS_Store
 bin/configlet
 bin/configlet.exe
+.problem-specifications/
+**/__pycache__/

--- a/bin/data.py
+++ b/bin/data.py
@@ -1,0 +1,391 @@
+# Credit: this code was copied from the Python track and adapted to Roc
+
+from enum import Enum
+from dataclasses import dataclass, asdict, fields
+import dataclasses
+from itertools import chain
+import json
+from pathlib import Path
+from typing import List, Any, Dict
+
+# Tomli was subsumed into Python 3.11.x, but was renamed to to tomllib.
+# This avoids ci failures for Python < 3.11.2.
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+
+
+def _custom_dataclass_init(self, *args, **kwargs):
+    # print(self.__class__.__name__, "__init__")
+    names = [field.name for field in fields(self)]
+    used_names = set()
+
+    # Handle positional arguments
+    for value in args:
+        try:
+            name = names.pop(0)
+        except IndexError:
+            raise TypeError("__init__() given too many positional arguments")
+        # print(f'setting {k}={v}')
+        setattr(self, name, value)
+        used_names.add(name)
+
+    # Handle keyword arguments
+    for name, value in kwargs.items():
+        if name in names:
+            # print(f'setting {k}={v}')
+            setattr(self, name, value)
+            used_names.add(name)
+        elif name in used_names:
+            raise TypeError(f"__init__() got multiple values for argument '{name}'")
+        else:
+            raise TypeError(
+                f"Unrecognized field '{name}' for dataclass {self.__class__.__name__}."
+                "\nIf this field is valid, please add it to the dataclass in data.py."
+                "\nIf adding an object-type field, please create a new dataclass for it."
+            )
+
+    # Check for missing positional arguments
+    missing = [
+        f"'{field.name}'"
+        for field in fields(self)
+        if isinstance(field.default, dataclasses._MISSING_TYPE)
+        and field.name not in used_names
+    ]
+    if len(missing) == 1:
+        raise TypeError(
+            f"__init__() missing 1 required positional argument: {missing[0]}"
+        )
+    elif len(missing) == 2:
+        raise TypeError(
+            f"__init__() missing 2 required positional arguments: {' and '.join(missing)}"
+        )
+    elif len(missing) != 0:
+        missing[-1] = f"and {missing[-1]}"
+        raise TypeError(
+            f"__init__() missing {len(missing)} required positional arguments: {', '.join(missing)}"
+        )
+
+    # Run post init if available
+    if hasattr(self, "__post_init__"):
+        self.__post_init__()
+
+
+@dataclass
+class TrackStatus:
+    __init__ = _custom_dataclass_init
+
+    concept_exercises: bool = False
+    test_runner: bool = False
+    representer: bool = False
+    analyzer: bool = False
+
+
+class IndentStyle(str, Enum):
+    Space = "space"
+    Tab = "tab"
+
+
+@dataclass
+class TestRunnerSettings:
+    average_run_time: float = -1
+
+
+@dataclass
+class EditorSettings:
+    __init__ = _custom_dataclass_init
+
+    indent_style: IndentStyle = IndentStyle.Space
+    indent_size: int = 4
+    ace_editor_language: str = "python"
+    highlightjs_language: str = "python"
+
+    def __post_init__(self):
+        if isinstance(self.indent_style, str):
+            self.indent_style = IndentStyle(self.indent_style)
+
+
+class ExerciseStatus(str, Enum):
+    Active = "active"
+    WIP = "wip"
+    Beta = "beta"
+    Deprecated = "deprecated"
+
+
+@dataclass
+class ExerciseFiles:
+    __init__ = _custom_dataclass_init
+
+    solution: List[str]
+    test: List[str]
+    editor: List[str] = None
+    exemplar: List[str] = None
+
+    # practice exercises are different
+    example: List[str] = None
+
+    def __post_init__(self):
+        if self.exemplar is None:
+            if self.example is None:
+                raise ValueError(
+                    "exercise config must have either files.exemplar or files.example"
+                )
+            else:
+                self.exemplar = self.example
+                delattr(self, "example")
+        elif self.example is not None:
+            raise ValueError(
+                "exercise config must have either files.exemplar or files.example, but not both"
+            )
+
+
+@dataclass
+class ExerciseConfig:
+    __init__ = _custom_dataclass_init
+
+    files: ExerciseFiles
+    authors: List[str] = None
+    forked_from: str = None
+    contributors: List[str] = None
+    language_versions: List[str] = None
+    test_runner: bool = True
+    source: str = None
+    source_url: str = None
+    blurb: str = None
+    icon: str = None
+
+    def __post_init__(self):
+        if isinstance(self.files, dict):
+            self.files = ExerciseFiles(**self.files)
+        for attr in ["authors", "contributors", "language_versions"]:
+            if getattr(self, attr) is None:
+                setattr(self, attr, [])
+
+    @classmethod
+    def load(cls, config_file: Path) -> "ExerciseConfig":
+        with config_file.open() as f:
+            return cls(**json.load(f))
+
+
+@dataclass
+class ExerciseInfo:
+    __init__ = _custom_dataclass_init
+
+    path: Path
+    slug: str
+    name: str
+    uuid: str
+    prerequisites: List[str]
+    type: str = "practice"
+    status: ExerciseStatus = ExerciseStatus.Active
+
+    # concept only
+    concepts: List[str] = None
+
+    # practice only
+    difficulty: int = 1
+    topics: List[str] = None
+    practices: List[str] = None
+
+    def __post_init__(self):
+        if self.concepts is None:
+            self.concepts = []
+        if self.topics is None:
+            self.topics = []
+        if self.practices is None:
+            self.practices = []
+        if isinstance(self.status, str):
+            self.status = ExerciseStatus(self.status)
+
+    @property
+    def solution_stub(self):
+        return next(
+            (
+                p
+                for p in self.path.glob("*.roc")
+                if not p.name.endswith("-test.roc") and p.name != "Example.roc"
+            ),
+            None,
+        )
+
+    @property
+    def helper_file(self):
+        return next(self.path.glob("*Data.roc"), None)
+
+    @property
+    def test_file(self):
+        return next(self.path.glob("*-test.roc"), None)
+
+    @property
+    def meta_dir(self):
+        return self.path / ".meta"
+
+    @property
+    def exemplar_file(self):
+        if self.type == "concept":
+            return self.meta_dir / "Exemplar.roc"
+        return self.meta_dir / "Example.roc"
+
+    @property
+    def template_path(self):
+        return self.meta_dir / "template.j2"
+
+    @property
+    def config_file(self):
+        return self.meta_dir / "config.json"
+
+    def load_config(self) -> ExerciseConfig:
+        return ExerciseConfig.load(self.config_file)
+
+
+@dataclass
+class Exercises:
+    __init__ = _custom_dataclass_init
+
+    concept: List[ExerciseInfo]
+    practice: List[ExerciseInfo]
+    foregone: List[str] = None
+
+    def __post_init__(self):
+        if self.foregone is None:
+            self.foregone = []
+        for attr_name in ["concept", "practice"]:
+            base_path = Path("exercises") / attr_name
+            setattr(
+                self,
+                attr_name,
+                [
+                    (
+                        ExerciseInfo(path=(base_path / e["slug"]), type=attr_name, **e)
+                        if isinstance(e, dict)
+                        else e
+                    )
+                    for e in getattr(self, attr_name)
+                ],
+            )
+
+    def all(self, status_filter={ExerciseStatus.Active, ExerciseStatus.Beta}):
+        return [
+            e for e in chain(self.concept, self.practice) if e.status in status_filter
+        ]
+
+
+@dataclass
+class Concept:
+    __init__ = _custom_dataclass_init
+
+    uuid: str
+    slug: str
+    name: str
+
+
+@dataclass
+class Feature:
+    __init__ = _custom_dataclass_init
+
+    title: str
+    content: str
+    icon: str
+
+
+@dataclass
+class FilePatterns:
+    __init__ = _custom_dataclass_init
+
+    solution: List[str]
+    test: List[str]
+    example: List[str]
+    exemplar: List[str]
+    editor: List[str] = None
+
+
+@dataclass
+class Config:
+    __init__ = _custom_dataclass_init
+
+    language: str
+    slug: str
+    active: bool
+    status: TrackStatus
+    blurb: str
+    version: int
+    online_editor: EditorSettings
+    exercises: Exercises
+    concepts: List[Concept]
+    key_features: List[Feature] = None
+    tags: List[Any] = None
+    test_runner: TestRunnerSettings = None
+    files: FilePatterns = None
+
+    def __post_init__(self):
+        if isinstance(self.status, dict):
+            self.status = TrackStatus(**self.status)
+        if isinstance(self.online_editor, dict):
+            self.online_editor = EditorSettings(**self.online_editor)
+        if isinstance(self.test_runner, dict):
+            self.test_runner = TestRunnerSettings(**self.test_runner)
+        if isinstance(self.exercises, dict):
+            self.exercises = Exercises(**self.exercises)
+        if isinstance(self.files, dict):
+            self.files = FilePatterns(**self.files)
+        self.concepts = [
+            (Concept(**c) if isinstance(c, dict) else c) for c in self.concepts
+        ]
+        if self.key_features is None:
+            self.key_features = []
+        if self.tags is None:
+            self.tags = []
+
+    @classmethod
+    def load(cls, path="config.json"):
+        try:
+            with Path(path).open() as f:
+                return cls(**json.load(f))
+        except IOError:
+            print(f"FAIL: {path} file not found")
+            raise SystemExit(1)
+        except TypeError as ex:
+            print(f"FAIL: {ex}")
+            raise SystemExit(1)
+
+
+@dataclass
+class TestCaseTOML:
+    __init__ = _custom_dataclass_init
+
+    uuid: str
+    description: str
+    include: bool = True
+    comment: str = ""
+
+
+@dataclass
+class TestsTOML:
+    __init__ = _custom_dataclass_init
+
+    cases: Dict[str, TestCaseTOML]
+
+    @classmethod
+    def load(cls, toml_path: Path):
+        with toml_path.open("rb") as f:
+            data = tomllib.load(f)
+        return cls(
+            {
+                uuid: TestCaseTOML(uuid, *opts)
+                for uuid, opts in data.items()
+                if opts.get("include", None) is not False
+            }
+        )
+
+
+if __name__ == "__main__":
+
+    class CustomEncoder(json.JSONEncoder):
+        def default(self, obj):
+            if isinstance(obj, Path):
+                return str(obj)
+            return json.JSONEncoder.default(self, obj)
+
+    config = Config.load()
+    print(json.dumps(asdict(config), cls=CustomEncoder, indent=2))

--- a/bin/generate_tests.py
+++ b/bin/generate_tests.py
@@ -1,0 +1,499 @@
+#!/usr/bin/env python3
+"""
+Generates exercise test suites using an exercise's canonical-data.json
+(found in problem-specifications) and $exercise/.meta/template.j2.
+If either does not exist, generation will not be attempted.
+
+Usage:
+    generate_tests.py           Generates tests for all exercises
+    generate_tests.py two-fer   Generates tests for two-fer exercise
+    generate_tests.py t*        Generates tests for all exercises matching t*
+
+    generate_tests.py --check           Checks if test files are out of sync with templates
+    generate_tests.py --check two-fer   Checks if two-fer test file is out of sync with template
+"""
+
+# Credit: this code was copied from the Python track and adapted for Roc.
+
+import sys
+
+_py = sys.version_info
+if _py.major < 3 or (_py.major == 3 and _py.minor < 7):
+    print("Python version must be at least 3.7")
+    sys.exit(1)
+
+# flake8: noqa: E402 # ignore the fact that these imports are not at the top
+import argparse
+from datetime import datetime
+from datetime import timezone
+import difflib
+import filecmp
+import importlib.util
+import json
+import logging
+from pathlib import Path, PureWindowsPath
+import re
+import shutil
+from itertools import repeat
+from string import punctuation, whitespace
+import subprocess
+from tempfile import NamedTemporaryFile
+from textwrap import wrap
+from typing import Any, Dict, List, NoReturn, Union
+
+# Tomli was subsumed into Python 3.11.x, but was renamed to to tomllib.
+# This avoids ci failures for Python < 3.11.2.
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+
+from jinja2 import Environment, FileSystemLoader, TemplateNotFound, UndefinedError
+from dateutil.parser import parse
+
+from data import TestsTOML
+
+VERSION = "0.3.0"
+GENERATED_ON_PREFIX = "# File last updated on "
+
+
+TypeJSON = Dict[str, Any]
+
+PROBLEM_SPEC_REPO = "https://github.com/exercism/problem-specifications.git"
+DEFAULT_SPEC_LOCATION = Path(".problem-specifications")
+RGX_WORDS = re.compile(r"[-_\s]|(?=[A-Z])")
+
+logging.basicConfig()
+logger = logging.getLogger("generator")
+logger.setLevel(logging.WARN)
+
+
+def replace_all(string: str, chars: Union[str, List[str]], rep: str) -> str:
+    """
+    Replace any char in chars with rep, reduce runs and strip terminal ends.
+    """
+    trans = str.maketrans(dict(zip(chars, repeat(rep))))
+    return re.sub("{0}+".format(re.escape(rep)), rep, string.translate(trans)).strip(
+        rep
+    )
+
+
+def to_snake(string: str, wordchars_only: bool = False) -> str:
+    """
+    Convert pretty much anything to snake_case.
+
+    By default whitespace and punctuation will be converted
+    to underscores as well, pass wordchars_only=True to preserve these as is.
+    """
+    clean = re.sub("(.)([A-Z][a-z]+)", r"\1_\2", string)
+    clean = re.sub("([a-z0-9])([A-Z])", r"\1_\2", clean).lower()
+    return (
+        clean if wordchars_only else replace_all(clean, whitespace + punctuation, "_")
+    )
+
+
+def to_kebab(string: str, wordchars_only: bool = False) -> str:
+    """
+    Convert pretty much anything to kebab-case.
+
+    By default whitespace and punctuation will be converted
+    to dashes as well, pass wordchars_only=True to preserve these as is.
+    """
+    return to_snake(string, wordchars_only).replace("_", "-")
+
+
+def to_pascal(string: str) -> str:
+    """
+    Convert pretty much anything to PascalCase.
+    """
+    return "".join(w.title() for w in to_snake(string).split("_"))
+
+
+def wrap_overlong(string: str, width: int = 70) -> List[str]:
+    """
+    Break an overly long string literal into escaped lines.
+    """
+    return ["{0!r} \\".format(w) for w in wrap(string, width)]
+
+
+def parse_datetime(string: str, strip_module: bool = False) -> datetime:
+    """
+    Parse a (hopefully ISO 8601) datestamp to a datetime object and
+    return its repr for use in a jinja2 template.
+
+    If used the template will need to import the datetime module.
+
+        import datetime
+
+    However if strip_module is True then the template will need to
+    import the datetime _class_ instead.
+
+        from datetime import datetime
+    """
+    result = repr(parse(string))
+    if strip_module:
+        return result.replace("datetime.", "", 1)
+    return result
+
+
+INVALID_ESCAPE_RE = re.compile(
+    r"""
+    \\(?!                           # a backslash NOT followed by
+        newline                     # the literal newline
+    |[                              # OR precisely one of
+        \\                          # another backslash
+        '                           # the single quote
+        "                           # the double quote
+        a                           # the ASCII bell
+        b                           # the ASCII backspace
+        f                           # the ASCII formfeed
+        n                           # the ASCII linefeed
+        r                           # the ASCII carriage return
+        t                           # the ASCII horizontal tab
+        v                           # the ASCII vertical tab
+    ]|                              # OR
+        o(?:[0-8]{1,3})             # an octal value
+    |                               # OR
+        x(?:[0-9A-Fa-f]{2})         # a hexadecimal value
+    |                               # OR
+        N                           # a unicode char name composed of
+        \{                          # an opening brace
+            [A-Z][A-Z\ \-]*[A-Z]    # uppercase WORD, WORDs (or WORD-WORDs)
+        \}                          # and a closing brace
+    |                               # OR
+        u(?:[0-9A-Fa-f]{4})         # a 16-bit unicode char
+    |                               # OR
+        U(?:[0-9A-Fa-f]{8})         # a 32-bit unicode char
+    )""",
+    flags=re.VERBOSE,
+)
+
+
+def escape_invalid_escapes(string: str) -> str:
+    """
+    Some canonical data includes invalid escape sequences, which
+    need to be properly escaped before template render.
+    """
+    return INVALID_ESCAPE_RE.sub(r"\\\\", string)
+
+
+ALL_VALID = (
+    r"\newline\\\'\"\a\b\f\n\r\t\v\o123" r"\xFF\N{GREATER-THAN SIGN}\u0394\U00000394"
+)
+
+assert ALL_VALID == escape_invalid_escapes(ALL_VALID)
+
+
+def get_tested_properties(spec: TypeJSON) -> List[str]:
+    """
+    Get set of tested properties from spec. Include nested cases.
+    """
+    props = set()
+    for case in spec["cases"]:
+        if "property" in case:
+            props.add(case["property"])
+        if "cases" in case:
+            props.update(get_tested_properties(case))
+    return sorted(props)
+
+
+def error_case(case: TypeJSON) -> bool:
+    return (
+        "expected" in case
+        and isinstance(case["expected"], dict)
+        and "error" in case["expected"]
+    )
+
+
+def has_error_case(cases: List[TypeJSON]) -> bool:
+    cases = cases[:]
+    while cases:
+        case = cases.pop(0)
+        if error_case(case):
+            return True
+        cases.extend(case.get("cases", []))
+    return False
+
+
+def regex_replace(s: str, find: str, repl: str) -> str:
+    return re.sub(find, repl, s)
+
+
+def regex_find(s: str, find: str) -> List[Any]:
+    return re.findall(find, s)
+
+
+def regex_split(s: str, find: str) -> List[str]:
+    return re.split(find, s)
+
+
+def filter_test_cases(cases: List[TypeJSON], opts: TestsTOML) -> List[TypeJSON]:
+    """
+    Returns a filtered copy of `cases` where only cases whose UUID is marked True in
+    `opts` are included.
+    """
+    filtered = []
+    for case in cases:
+        if "uuid" in case:
+            uuid = case["uuid"]
+            case_opts = opts.cases.get(uuid, None)
+            if case_opts is not None and case_opts.include:
+                filtered.append(case)
+            else:
+                logger.debug(f"uuid {uuid} either missing or not marked for include")
+        elif "cases" in case:
+            subfiltered = filter_test_cases(case["cases"], opts)
+            if subfiltered:
+                case_copy = dict(case)
+                case_copy["cases"] = subfiltered
+                filtered.append(case_copy)
+    return filtered
+
+
+def load_canonical(exercise: str, spec_path: Path, test_opts: TestsTOML) -> TypeJSON:
+    """
+    Loads the canonical data for an exercise as a nested dictionary
+    """
+    full_path = spec_path / "exercises" / exercise / "canonical-data.json"
+    with full_path.open() as f:
+        spec = json.load(f)
+    spec["cases"] = filter_test_cases(spec["cases"], test_opts)
+    spec["properties"] = get_tested_properties(spec)
+    return spec
+
+
+def load_additional_tests(exercise: Path) -> List[TypeJSON]:
+    """
+    Loads additional tests from .meta/additional_tests.json
+    """
+    full_path = exercise / ".meta/additional_tests.json"
+    try:
+        with full_path.open() as f:
+            data = json.load(f)
+        return data.get("cases", [])
+    except FileNotFoundError:
+        return []
+
+
+def format_file(path: Path) -> NoReturn:
+    """
+    Runs roc format on file at path
+    """
+    subprocess.check_call(["roc", "format", path])
+
+
+def drop_timestamp(lines):
+    def drop(line):
+        try:
+            index = line.index(GENERATED_ON_PREFIX)
+            return line[:index].rstrip()
+        except ValueError:
+            return line
+
+    return [drop(line) for line in lines]
+
+
+def check_template(slug: str, tests_path: Path, tmpfile: Path):
+    """Generate a new test file and diff against existing file."""
+
+    try:
+        check_ok = True
+        if not tmpfile.is_file():
+            logger.debug(f"{slug}: tmp file {tmpfile} not found")
+            check_ok = False
+        if not tests_path.is_file():
+            logger.debug(f"{slug}: tests file {tests_path} not found")
+            check_ok = False
+        if check_ok and not filecmp.cmp(tmpfile, tests_path):
+            with tests_path.open() as f:
+                current_lines = drop_timestamp(f.readlines())
+            with tmpfile.open() as f:
+                rendered_lines = drop_timestamp(f.readlines())
+
+            diff = list(
+                difflib.unified_diff(
+                    current_lines,
+                    rendered_lines,
+                    fromfile=f"[current] {tests_path.name}",
+                    tofile=f"[generated] {tmpfile.name}",
+                    lineterm="\n",
+                )
+            )
+            if not diff:
+                check_ok = True
+            else:
+                logger.debug(f"{slug}: ##### DIFF START #####")
+                for line in diff:
+                    logger.debug(line.strip())
+                logger.debug(f"{slug}: ##### DIFF END #####")
+                check_ok = False
+        if not check_ok:
+            logger.error(
+                f"{slug}: check failed; tests must be regenerated with bin/generate_tests.py"
+            )
+            return False
+        logger.debug(f"{slug}: check passed")
+    finally:
+        logger.debug(f"{slug}: removing tmp file {tmpfile}")
+        tmpfile.unlink()
+    return True
+
+
+def generate_exercise(
+    env: Environment, spec_path: Path, exercise: Path, check: bool = False
+):
+    """
+    Renders test suite for exercise and if check is:
+    True: verifies that current tests file matches rendered
+    False: saves rendered to tests file
+    """
+    slug = exercise.name
+    meta_dir = exercise / ".meta"
+    plugins_module = None
+    plugins_name = "plugins"
+    plugins_source = meta_dir / f"{plugins_name}.py"
+    try:
+        if plugins_source.is_file():
+            plugins_spec = importlib.util.spec_from_file_location(
+                plugins_name, plugins_source
+            )
+            plugins_module = importlib.util.module_from_spec(plugins_spec)
+            sys.modules[plugins_name] = plugins_module
+            plugins_spec.loader.exec_module(plugins_module)
+        try:
+            test_opts = TestsTOML.load(meta_dir / "tests.toml")
+        except FileNotFoundError:
+            logger.error(f"{slug}: tests.toml not found; skipping.")
+            return True
+
+        spec = load_canonical(slug, spec_path, test_opts)
+        additional_tests = load_additional_tests(exercise)
+        spec["additional_cases"] = additional_tests
+        template_path = exercise.relative_to("exercises") / ".meta/template.j2"
+
+        # See https://github.com/pallets/jinja/issues/767 for why this is needed on Windows systems.
+        if "\\" in str(template_path):
+            template_path = PureWindowsPath(template_path).as_posix()
+
+        template = env.get_template(str(template_path))
+        tests_path = exercise / f"{to_kebab(slug)}-test.roc"
+        spec["has_error_case"] = has_error_case(spec["cases"])
+
+        if plugins_module is not None:
+            spec[plugins_name] = plugins_module
+        logger.debug(f"{slug}: attempting render")
+        rendered = template.render(**spec)
+        with NamedTemporaryFile("w", delete=False) as tmp:
+            logger.debug(f"{slug}: writing render to tmp file {tmp.name}")
+            tmpfile = Path(tmp.name)
+            tmp.write(rendered)
+        try:
+            logger.debug(f"{slug}: formatting tmp file {tmpfile}")
+            format_file(tmpfile)
+        except FileNotFoundError as e:
+            logger.error(f"{slug}: the black utility must be installed")
+            return False
+
+        if check:
+            return check_template(slug, tests_path, tmpfile)
+        else:
+            logger.debug(f"{slug}: moving tmp file {tmpfile}->{tests_path}")
+            shutil.move(tmpfile, tests_path)
+            print(f"{slug} generated at {tests_path}")
+    except (TypeError, UndefinedError, SyntaxError) as e:
+        logger.debug(str(e))
+        logger.error(f"{slug}: generation failed")
+        return False
+    except TemplateNotFound as e:
+        logger.debug(str(e))
+        logger.info(f"{slug}: no template found; skipping")
+    except FileNotFoundError as e:
+        logger.debug(str(e))
+        logger.info(f"{slug}: no canonical data found; skipping")
+    return True
+
+
+def clone_or_update_specs(dir_path, specs_url=PROBLEM_SPEC_REPO):
+    if dir_path.is_dir():
+        try:
+            subprocess.run(
+                ["git", "pull"],
+                cwd=dir_path,
+                check=True,
+                stdout=subprocess.DEVNULL,
+            )
+        except subprocess.CalledProcessError:
+            logger.warning("Failed to update the problem-specifications", exc_info=True)
+        return True
+    else:
+        try:
+            subprocess.run(["git", "clone", specs_url, str(dir_path)], check=True)
+            return True
+        except subprocess.CalledProcessError:
+            logger.error("Failed to clone problem-specifications", exc_info=True)
+    return False
+
+
+def generate(
+    exercise_glob: str,
+    spec_path: Path = DEFAULT_SPEC_LOCATION,
+    stop_on_failure: bool = False,
+    check: bool = False,
+    **_,
+):
+    """
+    Primary entry point. Generates test files for all exercises matching exercise_glob
+    """
+    loader = FileSystemLoader(["config", "exercises"])
+    env = Environment(loader=loader, keep_trailing_newline=True)
+    env.filters["to_snake"] = to_snake
+    env.filters["to_pascal"] = to_pascal
+    env.filters["wrap_overlong"] = wrap_overlong
+    env.filters["regex_replace"] = regex_replace
+    env.filters["regex_find"] = regex_find
+    env.filters["regex_split"] = regex_split
+    env.filters["zip"] = zip
+    env.filters["parse_datetime"] = parse_datetime
+    env.filters["escape_invalid_escapes"] = escape_invalid_escapes
+    env.globals["current_date"] = datetime.now(tz=timezone.utc).date()
+    env.tests["error_case"] = error_case
+    result = True
+    for exercise in sorted(Path("exercises/practice").glob(exercise_glob)):
+        if not generate_exercise(env, spec_path, exercise, check):
+            result = False
+            if stop_on_failure:
+                break
+    if not result:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("exercise_glob", nargs="?", default="*", metavar="EXERCISE")
+    parser.add_argument(
+        "--version",
+        action="version",
+        version="%(prog)s {} for Python {}".format(VERSION, sys.version.split("\n")[0]),
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument(
+        "-p",
+        "--spec-path",
+        default=DEFAULT_SPEC_LOCATION,
+        type=Path,
+        help=(
+            "path to clone of exercism/problem-specifications " "(default: %(default)s)"
+        ),
+    )
+    parser.add_argument("--stop-on-failure", action="store_true")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="check if tests are up-to-date, but do not modify test files",
+    )
+    opts = parser.parse_args()
+    if opts.verbose:
+        logger.setLevel(logging.DEBUG)
+
+    clone_or_update_specs(opts.spec_path)
+    sys.exit(generate(**opts.__dict__))

--- a/config/generator_macros.j2
+++ b/config/generator_macros.j2
@@ -1,0 +1,28 @@
+{# Usage: {%- import "generator_macros.j2" as macros -%} #}
+{# {{ macros.linebreak(text) }} #}
+
+{%- macro linebreak(s) %}
+{%- set parts = s.split(": ") -%}
+"{{ parts[0] }}: "
+{% for part in parts[1].split(", ") %}
+"{{ part }}{% if not loop.last %}, {% endif %}"
+{%- endfor %}
+{% endmacro -%}
+
+{% macro canonical_ref() -%}
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/{{ exercise }}/canonical-data.json
+# File last updated on {{ current_date }}
+{%- endmacro %}
+
+{% macro header(imports=[], ignore=[]) -%}
+
+app [main] { pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.12.0/Lb8EgiejTUzbggO2HVVuPJFkwvvsfW6LojkLR20kTVE.tar.br" }
+
+import pf.Task exposing [Task]
+
+main =
+    Task.ok {}
+
+{%- endmacro %}
+

--- a/exercises/practice/hello-world/.meta/template.j2
+++ b/exercises/practice/hello-world/.meta/template.j2
@@ -7,6 +7,6 @@ import HelloWorld exposing [hello]
 
 {% for case in cases -%}
 # {{ case["description"] }}
-expect {{ case["property"] }} == "{{- case ["expected"] }}"
+expect {{ case["property"] }} == {{ case ["expected"] | tojson }}
 
 {% endfor %}

--- a/exercises/practice/hello-world/.meta/template.j2
+++ b/exercises/practice/hello-world/.meta/template.j2
@@ -1,0 +1,12 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
+
+import HelloWorld exposing [hello]
+
+{% for case in cases -%}
+# {{ case["description"] }}
+expect {{ case["property"] }} == "{{- case ["expected"] }}"
+
+{% endfor %}

--- a/exercises/practice/hello-world/hello-world-test.roc
+++ b/exercises/practice/hello-world/hello-world-test.roc
@@ -1,9 +1,17 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/hello-world/canonical-data.json
+# File last updated on 2024-08-23
+
 app [main] { pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.12.0/Lb8EgiejTUzbggO2HVVuPJFkwvvsfW6LojkLR20kTVE.tar.br" }
 
 import pf.Task exposing [Task]
-import HelloWorld exposing [hello]
-
-expect hello == "Hello, World!"
 
 main =
     Task.ok {}
+
+import HelloWorld exposing [hello]
+
+# Say Hi!
+expect hello == "Hello, World!"
+
+

--- a/exercises/practice/leap/.meta/template.j2
+++ b/exercises/practice/leap/.meta/template.j2
@@ -1,0 +1,12 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+
+{{ macros.header()}}
+
+import Leap exposing [isLeapYear]
+
+{% for case in cases -%}
+# {{ case["description"] }}
+expect (isLeapYear {{ case["input"]["year"] }}) == Bool.{{- case ["expected"] | lower }}
+
+{% endfor %}

--- a/exercises/practice/leap/leap-test.roc
+++ b/exercises/practice/leap/leap-test.roc
@@ -1,26 +1,41 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/leap/canonical-data.json
+# File last updated on 2024-08-23
+
 app [main] { pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.12.0/Lb8EgiejTUzbggO2HVVuPJFkwvvsfW6LojkLR20kTVE.tar.br" }
 
 import pf.Task exposing [Task]
-import Leap exposing [isLeapYear]
-
-# year not divisible by 4 in common year
-expect !(isLeapYear 2015)
-# year divisible by 2, not divisible by 4 in common year
-expect !(isLeapYear 1970)
-# year divisible by 4, not divisible by 100 in leap year
-expect isLeapYear 1996
-# year divisible by 4 and 5 is still a leap year
-expect isLeapYear 1960
-# year divisible by 100, not divisible by 400 in common year
-expect !(isLeapYear 2100)
-# year divisible by 100 but not by 3 is still not a leap year
-expect !(isLeapYear 1900)
-# year divisible by 400 is leap year
-expect isLeapYear 2000
-# year divisible by 400 but not by 125 is still a leap year
-expect isLeapYear 2400
-# year divisible by 200, not divisible by 400 in common year
-expect !(isLeapYear 1800)
 
 main =
     Task.ok {}
+
+import Leap exposing [isLeapYear]
+
+# year not divisible by 4 in common year
+expect (isLeapYear 2015) == Bool.false
+
+# year divisible by 2, not divisible by 4 in common year
+expect (isLeapYear 1970) == Bool.false
+
+# year divisible by 4, not divisible by 100 in leap year
+expect (isLeapYear 1996) == Bool.true
+
+# year divisible by 4 and 5 is still a leap year
+expect (isLeapYear 1960) == Bool.true
+
+# year divisible by 100, not divisible by 400 in common year
+expect (isLeapYear 2100) == Bool.false
+
+# year divisible by 100 but not by 3 is still not a leap year
+expect (isLeapYear 1900) == Bool.false
+
+# year divisible by 400 is leap year
+expect (isLeapYear 2000) == Bool.true
+
+# year divisible by 400 but not by 125 is still a leap year
+expect (isLeapYear 2400) == Bool.true
+
+# year divisible by 200, not divisible by 400 in common year
+expect (isLeapYear 1800) == Bool.false
+
+

--- a/requirements-generator.txt
+++ b/requirements-generator.txt
@@ -1,0 +1,4 @@
+flake8~=7.1.1
+Jinja2~=3.1.4
+python-dateutil==2.9.0.post0
+tomli>=2.0.0; python_full_version < '3.11.2'


### PR DESCRIPTION
I copied Python's `bin/generate_tests.py` script and its dependencies (`bin/data.py`, `config/generator_macros.j2`, and `requirements-generator.txt`), and I adapted it to Roc.

To use:
* Create a `.meta/template.j2` file.
* Run `bin/generate_tests.py`

This will generate the `<slug>-test.roc` file for each exercise. See `bin/generate_tests.py --help` for more options.

I also added a `template.j2` file for the two existing exercises (`hello-world` and `leap`) and regenerated the test scripts.

Now that we have a `roc-test-runner` and generator script, and a couple working exercises, we can start adding new exercises quickly! 😊