### PR TITLE
Add to roc string filter

### DIFF
--- a/bin/generate_tests.py
+++ b/bin/generate_tests.py
@@ -117,6 +117,32 @@ def to_camel(string: str) -> str:
     return pascal[0].lower() + pascal[1:]
 
 
+ESCAPE_ROC_STRING = re.compile(r'[\x00-\x1f\\"\b\f\n\r\t]')
+ESCAPE_MAP = {
+    "\\": "\\\\",
+    '"': '\\"',
+    "\b": "\\b",
+    "\f": "\\f",
+    "\n": "\\n",
+    "\r": "\\r",
+    "\t": "\\t",
+}
+for i in range(0x20):
+    ESCAPE_MAP.setdefault(chr(i), f"\\u({i:04x})")
+del i
+
+
+def to_roc_string(string: str) -> str:
+    """
+    Return a Roc representation of a Python string
+    """
+    return (
+        '"'
+        + ESCAPE_ROC_STRING.sub(lambda match: ESCAPE_MAP[match.group(0)], string)
+        + '"'
+    ).replace("$(", "\\$(")
+
+
 def wrap_overlong(string: str, width: int = 70) -> List[str]:
     """
     Break an overly long string literal into escaped lines.
@@ -457,6 +483,7 @@ def generate(
     env.filters["to_snake"] = to_snake
     env.filters["to_pascal"] = to_pascal
     env.filters["to_camel"] = to_camel
+    env.filters["to_roc_string"] = to_roc_string
     env.filters["wrap_overlong"] = wrap_overlong
     env.filters["regex_replace"] = regex_replace
     env.filters["regex_find"] = regex_find

--- a/exercises/practice/bob/.meta/template.j2
+++ b/exercises/practice/bob/.meta/template.j2
@@ -6,6 +6,6 @@ import {{ exercise | to_pascal }} exposing [response]
 
 {% for case in cases -%}
 # {{ case["description"] }}
-expect {{ case["property"] | to_camel }} {{ case["input"]["heyBob"] | tojson }} == {{ case["expected"] | tojson }}
+expect {{ case["property"] | to_camel }} {{ case["input"]["heyBob"] | to_roc_string }} == {{ case["expected"] | to_roc_string }}
 
 {% endfor %}

--- a/exercises/practice/bob/bob-test.roc
+++ b/exercises/practice/bob/bob-test.roc
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/bob/canonical-data.json
-# File last updated on 2024-08-23
+# File last updated on 2024-08-24
 app [main] { pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.12.0/Lb8EgiejTUzbggO2HVVuPJFkwvvsfW6LojkLR20kTVE.tar.br" }
 
 import pf.Task exposing [Task]
@@ -32,10 +32,10 @@ expect response "fffbbcbeab?" == "Sure."
 expect response "Hi there!" == "Whatever."
 
 # using acronyms in regular speech
-# expect response "It\u0027s OK if you don\u0027t want to go work for NASA." == "Whatever."
+expect response "It's OK if you don't want to go work for NASA." == "Whatever."
 
 # forceful question
-# expect response "WHAT\u0027S GOING ON?" == "Calm down, I know what I\u0027m doing!"
+expect response "WHAT'S GOING ON?" == "Calm down, I know what I'm doing!"
 
 # shouting numbers
 expect response "1, 2, 3 GO!" == "Whoa, chill out!"
@@ -47,7 +47,7 @@ expect response "1, 2, 3" == "Whatever."
 expect response "4?" == "Sure."
 
 # shouting with special characters
-# expect response "ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!" == "Whoa, chill out!"
+expect response "ZOMG THE %^*@#\$(*^ ZOMBIES ARE COMING!!11!!1!" == "Whoa, chill out!"
 
 # shouting with no exclamation mark
 expect response "I HATE THE DENTIST" == "Whoa, chill out!"

--- a/exercises/practice/difference-of-squares/.meta/template.j2
+++ b/exercises/practice/difference-of-squares/.meta/template.j2
@@ -9,9 +9,9 @@ import DifferenceOfSquares exposing [squareOfSum, sumOfSquares, differenceOfSqua
 ## {{ supercase["description"] }}
 ##
 
-    {% for case in supercase["cases"] -%}
+{% for case in supercase["cases"] -%}
 # {{ case["description"] }}
 expect {{ case["property"] | to_camel }} {{ case["input"]["number"] }} == {{ case["expected"] }}
 
-  {% endfor %}
+{% endfor %}
 {% endfor %}

--- a/exercises/practice/hello-world/.meta/template.j2
+++ b/exercises/practice/hello-world/.meta/template.j2
@@ -7,6 +7,6 @@ import HelloWorld exposing [hello]
 
 {% for case in cases -%}
 # {{ case["description"] }}
-expect {{ case["property"] }} == {{ case ["expected"] | tojson }}
+expect {{ case["property"] }} == {{ case ["expected"] | to_roc_string }}
 
 {% endfor %}


### PR DESCRIPTION
Thiis PR adds a new `to_roc_string` jinja2 filter and replaces `tojson` with this new filter.
This fixes the 3 problematic test cases in `bob-test.roc`.
