### PR TITLE
Add reverse-string exercise, including support for unicode package

### DIFF
--- a/config.json
+++ b/config.json
@@ -75,6 +75,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1
+      },
+      {
+        "slug": "reverse-string",
+        "name": "Reverse String",
+        "uuid": "7bd2e210-08aa-45e9-8a19-f2213a22ac27",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1
       }
     ]
   },

--- a/config/generator_macros.j2
+++ b/config/generator_macros.j2
@@ -17,7 +17,18 @@
 
 {% macro header(imports=[], ignore=[]) -%}
 
-app [main] { pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.12.0/Lb8EgiejTUzbggO2HVVuPJFkwvvsfW6LojkLR20kTVE.tar.br" }
+app [main] {
+    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.12.0/Lb8EgiejTUzbggO2HVVuPJFkwvvsfW6LojkLR20kTVE.tar.br"
+{%- if imports -%}
+{%- for name in imports -%},
+    {% if name == "unicode" -%}
+    unicode: "https://github.com/roc-lang/unicode/releases/download/0.1.1/-FQDoegpSfMS-a7B0noOnZQs3-A2aq9RSOR5VVLMePg.tar.br"
+    {%- elif name == "toto" -%}
+    toto: "https://github.com/roc-lang/unicode/releases/toto"
+    {%- endif -%}
+{%- endfor -%}
+{%- endif %}
+}
 
 import pf.Task exposing [Task]
 

--- a/config/generator_macros.j2
+++ b/config/generator_macros.j2
@@ -23,8 +23,6 @@ app [main] {
 {%- for name in imports -%},
     {% if name == "unicode" -%}
     unicode: "https://github.com/roc-lang/unicode/releases/download/0.1.1/-FQDoegpSfMS-a7B0noOnZQs3-A2aq9RSOR5VVLMePg.tar.br"
-    {%- elif name == "toto" -%}
-    toto: "https://github.com/roc-lang/unicode/releases/toto"
     {%- endif -%}
 {%- endfor -%}
 {%- endif %}

--- a/exercises/practice/reverse-string/.docs/instructions.md
+++ b/exercises/practice/reverse-string/.docs/instructions.md
@@ -1,0 +1,9 @@
+# Instructions
+
+Your task is to reverse a given string.
+
+Some examples:
+
+- Turn `"stressed"` into `"desserts"`.
+- Turn `"strops"` into `"sports"`.
+- Turn `"racecar"` into `"racecar"`.

--- a/exercises/practice/reverse-string/.docs/introduction.md
+++ b/exercises/practice/reverse-string/.docs/introduction.md
@@ -1,0 +1,5 @@
+# Introduction
+
+Reversing strings (reading them from right to left, rather than from left to right) is a surprisingly common task in programming.
+
+For example, in bioinformatics, reversing the sequence of DNA or RNA strings is often important for various analyses, such as finding complementary strands or identifying palindromic sequences that have biological significance.

--- a/exercises/practice/reverse-string/.meta/Example.roc
+++ b/exercises/practice/reverse-string/.meta/Example.roc
@@ -1,0 +1,30 @@
+module [reverse, reverseAscii]
+
+import unicode.Grapheme
+
+## This function reverses the input string, e.g., "café" -> "éfac".
+## This implementation uses the `unicode` package from github.com/roc-lang/unicode
+## to split the input string into separate "Extended Grapheme Clusters". This is a
+## fancy Unicode name for characters that human beings recognize as such: each EGC
+## may actually be composed of several Unicode codepoints, e.g., the character
+## é is recognized as a single character, but it may actually be represented as two
+## Unicode codepoints (e + ´).
+## To use the `unicode` package, its URL must be added to the app's header.
+## Luckily, we've added it for you in reverse-string-test.roc. Take a look!
+reverse = \string ->
+    if string == "" then
+        ""
+    else
+        graphemes = string |> Grapheme.split
+        when graphemes is
+            Ok gs -> gs |> List.reverse |> Str.joinWith ""
+            Err _ -> "Ooops"
+
+
+## This function reverses the input string, e.g., "hello" -> "olleh". It is
+## faster and simpler than the implementation above, plus it does not require an
+## external package, but it is only guaranteed to work on ASCII strings.
+reverseAscii = \string ->
+    when string |> Str.toUtf8 |> List.reverse |> Str.fromUtf8 is
+        Ok reversed -> reversed
+        Err _ -> "This implementation online works on ASCII strings"

--- a/exercises/practice/reverse-string/.meta/config.json
+++ b/exercises/practice/reverse-string/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "ageron"
+  ],
+  "files": {
+    "solution": [
+      "ReverseString.roc"
+    ],
+    "test": [
+      "reverse-string-test.roc"
+    ],
+    "example": [
+      ".meta/Example.roc"
+    ]
+  },
+  "blurb": "Reverse a given string.",
+  "source": "Introductory challenge to reverse an input string",
+  "source_url": "https://medium.freecodecamp.org/how-to-reverse-a-string-in-javascript-in-3-different-ways-75e4763c68cb"
+}

--- a/exercises/practice/reverse-string/.meta/template.j2
+++ b/exercises/practice/reverse-string/.meta/template.j2
@@ -1,0 +1,11 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+{{ macros.header(imports=["unicode"]) }}
+
+import {{ exercise | to_pascal }} exposing [reverse]
+
+{% for case in cases -%}
+# {{ case["description"] }}
+expect {{ case["property"] | to_camel }} {{ case["input"]["value"] | to_roc_string }} == {{ case["expected"] | to_roc_string }}
+
+{% endfor %}

--- a/exercises/practice/reverse-string/.meta/tests.toml
+++ b/exercises/practice/reverse-string/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[c3b7d806-dced-49ee-8543-933fd1719b1c]
+description = "an empty string"
+
+[01ebf55b-bebb-414e-9dec-06f7bb0bee3c]
+description = "a word"
+
+[0f7c07e4-efd1-4aaa-a07a-90b49ce0b746]
+description = "a capitalized word"
+
+[71854b9c-f200-4469-9f5c-1e8e5eff5614]
+description = "a sentence with punctuation"
+
+[1f8ed2f3-56f3-459b-8f3e-6d8d654a1f6c]
+description = "a palindrome"
+
+[b9e7dec1-c6df-40bd-9fa3-cd7ded010c4c]
+description = "an even-sized word"
+
+[1bed0f8a-13b0-4bd3-9d59-3d0593326fa2]
+description = "wide characters"
+
+[93d7e1b8-f60f-4f3c-9559-4056e10d2ead]
+description = "grapheme cluster with pre-combined form"
+
+[1028b2c1-6763-4459-8540-2da47ca512d9]
+description = "grapheme clusters"

--- a/exercises/practice/reverse-string/ReverseString.roc
+++ b/exercises/practice/reverse-string/ReverseString.roc
@@ -1,0 +1,30 @@
+module [reverse]
+
+import unicode.Grapheme
+
+## This function reverses the input string, e.g., "café" -> "éfac".
+## This implementation uses the `unicode` package from github.com/roc-lang/unicode
+## to split the input string into separate "Extended Grapheme Clusters". This is a
+## fancy Unicode name for characters that human beings recognize as such: each EGC
+## may actually be composed of several Unicode codepoints, e.g., the character
+## é is recognized as a single character, but it may actually be represented as two
+## Unicode codepoints (e + ´).
+## To use the `unicode` package, its URL must be added to the app's header.
+## Luckily, we've added it for you in reverse-string-test.roc. Take a look!
+reverse = \string ->
+    if string == "" then
+        ""
+    else
+        graphemes = string |> Grapheme.split
+        when graphemes is
+            Ok gs -> gs |> List.reverse |> Str.joinWith ""
+            Err _ -> "Ooops"
+
+
+## This function reverses the input string, e.g., "hello" -> "olleh". It is
+## faster and simpler than the implementation above, and it does not use an
+## external package, but it is only guaranteed to work on ASCII strings.
+_reverseAscii = \string ->
+    when string |> Str.toUtf8 |> List.reverse |> Str.fromUtf8 is
+        Ok reversed -> reversed
+        Err _ -> "This implementation online works on ASCII strings"

--- a/exercises/practice/reverse-string/ReverseString.roc
+++ b/exercises/practice/reverse-string/ReverseString.roc
@@ -1,30 +1,8 @@
 module [reverse]
 
-import unicode.Grapheme
-
-## This function reverses the input string, e.g., "café" -> "éfac".
-## This implementation uses the `unicode` package from github.com/roc-lang/unicode
-## to split the input string into separate "Extended Grapheme Clusters". This is a
-## fancy Unicode name for characters that human beings recognize as such: each EGC
-## may actually be composed of several Unicode codepoints, e.g., the character
-## é is recognized as a single character, but it may actually be represented as two
-## Unicode codepoints (e + ´).
-## To use the `unicode` package, its URL must be added to the app's header.
-## Luckily, we've added it for you in reverse-string-test.roc. Take a look!
 reverse = \string ->
-    if string == "" then
-        ""
-    else
-        graphemes = string |> Grapheme.split
-        when graphemes is
-            Ok gs -> gs |> List.reverse |> Str.joinWith ""
-            Err _ -> "Ooops"
+    crash "Please implement the `reverse` function"
 
-
-## This function reverses the input string, e.g., "hello" -> "olleh". It is
-## faster and simpler than the implementation above, and it does not use an
-## external package, but it is only guaranteed to work on ASCII strings.
-_reverseAscii = \string ->
-    when string |> Str.toUtf8 |> List.reverse |> Str.fromUtf8 is
-        Ok reversed -> reversed
-        Err _ -> "This implementation online works on ASCII strings"
+    # HINT: we have added the `unicode` package to the app's header in
+    #       reverse-string-test.roc, so you can use it here if you need to.
+    #       For example, you could use unicode.Grapheme, just sayin'.

--- a/exercises/practice/reverse-string/reverse-string-test.roc
+++ b/exercises/practice/reverse-string/reverse-string-test.roc
@@ -1,0 +1,43 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/reverse-string/canonical-data.json
+# File last updated on 2024-08-25
+app [main] {
+    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.12.0/Lb8EgiejTUzbggO2HVVuPJFkwvvsfW6LojkLR20kTVE.tar.br",
+    unicode: "https://github.com/roc-lang/unicode/releases/download/0.1.1/-FQDoegpSfMS-a7B0noOnZQs3-A2aq9RSOR5VVLMePg.tar.br"
+}
+
+import pf.Task exposing [Task]
+
+main =
+    Task.ok {}
+
+import ReverseString exposing [reverse]
+
+# an empty string
+expect reverse "" == ""
+
+# a word
+expect reverse "robot" == "tobor"
+
+# a capitalized word
+expect reverse "Ramen" == "nemaR"
+
+# a sentence with punctuation
+expect reverse "I'm hungry!" == "!yrgnuh m'I"
+
+# a palindrome
+expect reverse "racecar" == "racecar"
+
+# an even-sized word
+expect reverse "drawer" == "reward"
+
+# wide characters
+expect reverse "子猫" == "猫子"
+
+# grapheme cluster with pre-combined form
+expect reverse "Würstchenstand" == "dnatsnehctsrüW"
+
+# grapheme clusters
+expect reverse "ผู้เขียนโปรแกรม" == "มรกแรปโนยขีเผู้"
+
+


### PR DESCRIPTION
Add the `reverse-string` exercise. This involved using the `unicode` package, which required tweaking `generate_macros.j2` to make it possible to add external packages.
Note that there seems to be an issue in the `unicode` package which makes `Grapheme.split` fail on empty strings (see [#15](https://github.com/roc-lang/unicode/issues/15)), so I had to explicitely handle that case separately. Once the issue is resolved, I'll remove this test.
I also included an ASCII-only implementation, which is simpler and doesn't require an external package, but does not support non-ASCII characters.