### PR TITLE
Add gigasecond exercise using imclerran/roc-isodate package

### DIFF
--- a/config.json
+++ b/config.json
@@ -99,6 +99,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1
+      },
+      {
+        "slug": "gigasecond",
+        "name": "Gigasecond",
+        "uuid": "8ab57d21-e5ec-49bb-b75d-c3f1da8e77ab",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1
       }
     ]
   },

--- a/config/generator_macros.j2
+++ b/config/generator_macros.j2
@@ -23,6 +23,8 @@ app [main] {
 {%- for name in imports -%},
     {% if name == "unicode" -%}
     unicode: "https://github.com/roc-lang/unicode/releases/download/0.1.1/-FQDoegpSfMS-a7B0noOnZQs3-A2aq9RSOR5VVLMePg.tar.br"
+    {%- elif name == "isodate" -%}
+    isodate: "https://github.com/imclerran/roc-isodate/releases/download/v0.4.1/OQwyjDUYQkmGRiaISkzBcw5dpnbi1OHi8KUDl7NZmC8.tar.br"
     {%- endif -%}
 {%- endfor -%}
 {%- endif %}

--- a/exercises/practice/gigasecond/.docs/instructions.md
+++ b/exercises/practice/gigasecond/.docs/instructions.md
@@ -1,0 +1,8 @@
+# Instructions
+
+Your task is to determine the date and time one gigasecond after a certain date.
+
+A gigasecond is one thousand million seconds.
+That is a one with nine zeros after it.
+
+If you were born on _January 24th, 2015 at 22:00 (10:00:00pm)_, then you would be a gigasecond old on _October 2nd, 2046 at 23:46:40 (11:46:40pm)_.

--- a/exercises/practice/gigasecond/.docs/introduction.md
+++ b/exercises/practice/gigasecond/.docs/introduction.md
@@ -1,0 +1,24 @@
+# Introduction
+
+The way we measure time is kind of messy.
+We have 60 seconds in a minute, and 60 minutes in an hour.
+This comes from ancient Babylon, where they used 60 as the basis for their number system.
+We have 24 hours in a day, 7 days in a week, and how many days in a month?
+Well, for days in a month it depends not only on which month it is, but also on what type of calendar is used in the country you live in.
+
+What if, instead, we only use seconds to express time intervals?
+Then we can use metric system prefixes for writing large numbers of seconds in more easily comprehensible quantities.
+
+- A food recipe might explain that you need to let the brownies cook in the oven for two kiloseconds (that's two thousand seconds).
+- Perhaps you and your family would travel to somewhere exotic for two megaseconds (that's two million seconds).
+- And if you and your spouse were married for _a thousand million_ seconds, you would celebrate your one gigasecond anniversary.
+
+~~~~exercism/note
+If we ever colonize Mars or some other planet, measuring time is going to get even messier.
+If someone says "year" do they mean a year on Earth or a year on Mars?
+
+The idea for this exercise came from the science fiction novel ["A Deepness in the Sky"][vinge-novel] by author Vernor Vinge.
+In it the author uses the metric system as the basis for time measurements.
+
+[vinge-novel]: https://www.tor.com/2017/08/03/science-fiction-with-something-for-everyone-a-deepness-in-the-sky-by-vernor-vinge/
+~~~~

--- a/exercises/practice/gigasecond/.meta/Example.roc
+++ b/exercises/practice/gigasecond/.meta/Example.roc
@@ -1,0 +1,22 @@
+module [add]
+
+import isodate.DateTime
+
+futureDatetime : Str -> Result Str [InvalidDateTimeFormat]
+futureDatetime = \moment ->
+    Ok
+        (
+            DateTime.fromIsoStr? moment
+                |> DateTime.toNanosSinceEpoch
+                |> Num.divTrunc 1_000_000_000 # nanos to seconds
+                |> Num.add 1_000_000_000 # add a gigasecond
+                |> Num.mul 1_000_000_000 # back to nanos
+                |> DateTime.fromNanosSinceEpoch
+                |> DateTime.toIsoStr
+        )
+
+add : Str -> Str
+add = \moment ->
+    when futureDatetime moment is
+        Ok string -> string
+        Err _ -> "Unexpected error"

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "ageron"
+  ],
+  "files": {
+    "solution": [
+      "Gigasecond.roc"
+    ],
+    "test": [
+      "gigasecond-test.roc"
+    ],
+    "example": [
+      ".meta/Example.roc"
+    ]
+  },
+  "blurb": "Given a moment, determine the moment that would be after a gigasecond has passed.",
+  "source": "Chapter 9 in Chris Pine's online Learn to Program tutorial.",
+  "source_url": "https://pine.fm/LearnToProgram/?Chapter=09"
+}

--- a/exercises/practice/gigasecond/.meta/template.j2
+++ b/exercises/practice/gigasecond/.meta/template.j2
@@ -1,0 +1,11 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+{{ macros.header(imports=["isodate"]) }}
+
+import {{ exercise | to_pascal }} exposing [add]
+
+{% for case in cases -%}
+# {{ case["description"] }}
+expect {{ case["property"] | to_camel }} {{ case["input"]["moment"] | to_roc_string }} == {{ case["expected"] | to_roc_string }}
+
+{% endfor %}

--- a/exercises/practice/gigasecond/.meta/tests.toml
+++ b/exercises/practice/gigasecond/.meta/tests.toml
@@ -1,0 +1,29 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[92fbe71c-ea52-4fac-bd77-be38023cacf7]
+description = "date only specification of time"
+
+[6d86dd16-6f7a-47be-9e58-bb9fb2ae1433]
+description = "second test for date only specification of time"
+
+[77eb8502-2bca-4d92-89d9-7b39ace28dd5]
+description = "third test for date only specification of time"
+
+[c9d89a7d-06f8-4e28-a305-64f1b2abc693]
+description = "full time specified"
+
+[09d4e30e-728a-4b52-9005-be44a58d9eba]
+description = "full time with day roll-over"
+
+[fcec307c-7529-49ab-b0fe-20309197618a]
+description = "does not mutate the input"
+include = false

--- a/exercises/practice/gigasecond/Gigasecond.roc
+++ b/exercises/practice/gigasecond/Gigasecond.roc
@@ -1,0 +1,4 @@
+module [add]
+
+add = \moment ->
+    crash "Please implement the 'add' function"

--- a/exercises/practice/gigasecond/gigasecond-test.roc
+++ b/exercises/practice/gigasecond/gigasecond-test.roc
@@ -1,0 +1,30 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/gigasecond/canonical-data.json
+# File last updated on 2024-08-25
+app [main] {
+    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.14.0/dC5ceT962N_4jmoyoffVdphJ_4GlW3YMhAPyGPr-nU0.tar.br",
+    isodate: "https://github.com/imclerran/roc-isodate/releases/download/v0.4.1/OQwyjDUYQkmGRiaISkzBcw5dpnbi1OHi8KUDl7NZmC8.tar.br",
+}
+
+import pf.Task exposing [Task]
+
+main =
+    Task.ok {}
+
+import Gigasecond exposing [add]
+
+# date only specification of time
+expect add "2011-04-25" == "2043-01-01T01:46:40"
+
+# second test for date only specification of time
+expect add "1977-06-13" == "2009-02-19T01:46:40"
+
+# third test for date only specification of time
+expect add "1959-07-19" == "1991-03-27T01:46:40"
+
+# full time specified
+expect add "2015-01-24T22:00:00" == "2046-10-02T23:46:40"
+
+# full time with day roll-over
+expect add "2015-01-24T23:59:59" == "2046-10-03T01:46:39"
+


### PR DESCRIPTION
The imclerran/roc-isodate package has not yet been updated to remove `<-` backpassing, so the tests show some warnings, but they pass. I've submitted [PR #25](https://github.com/imclerran/roc-isodate/pull/25) to fix this issue.