### PR TITLE
Upgrade unicode package to 0.1.2 and update reverse-string exercise

### DIFF
--- a/config/generator_macros.j2
+++ b/config/generator_macros.j2
@@ -22,7 +22,7 @@ app [main] {
 {%- if imports -%}
 {%- for name in imports -%},
     {% if name == "unicode" -%}
-    unicode: "https://github.com/roc-lang/unicode/releases/download/0.1.1/-FQDoegpSfMS-a7B0noOnZQs3-A2aq9RSOR5VVLMePg.tar.br"
+    unicode: "https://github.com/roc-lang/unicode/releases/download/0.1.2/vH5iqn04ShmqP-pNemgF773f86COePSqMWHzVGrAKNo.tar.br"
     {%- elif name == "isodate" -%}
     isodate: "https://github.com/imclerran/roc-isodate/releases/download/v0.4.1/OQwyjDUYQkmGRiaISkzBcw5dpnbi1OHi8KUDl7NZmC8.tar.br"
     {%- endif -%}

--- a/exercises/practice/reverse-string/.meta/Example.roc
+++ b/exercises/practice/reverse-string/.meta/Example.roc
@@ -12,13 +12,9 @@ import unicode.Grapheme
 ## To use the `unicode` package, its URL must be added to the app's header.
 ## Luckily, we've added it for you in reverse-string-test.roc. Take a look!
 reverse = \string ->
-    if string == "" then
-        ""
-    else
-        graphemes = string |> Grapheme.split
-        when graphemes is
-            Ok gs -> gs |> List.reverse |> Str.joinWith ""
-            Err _ -> "Unexpected error: could not split the string into graphemes"
+    when Grapheme.split string is
+        Ok graphemes -> graphemes |> List.reverse |> Str.joinWith ""
+        Err _ -> "Unexpected error: could not split the string into graphemes"
 
 ## This function reverses the input string, e.g., "hello" -> "olleh". It is
 ## faster and simpler than the implementation above, plus it does not require an

--- a/exercises/practice/reverse-string/reverse-string-test.roc
+++ b/exercises/practice/reverse-string/reverse-string-test.roc
@@ -3,7 +3,7 @@
 # File last updated on 2024-08-25
 app [main] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.14.0/dC5ceT962N_4jmoyoffVdphJ_4GlW3YMhAPyGPr-nU0.tar.br",
-    unicode: "https://github.com/roc-lang/unicode/releases/download/0.1.1/-FQDoegpSfMS-a7B0noOnZQs3-A2aq9RSOR5VVLMePg.tar.br",
+    unicode: "https://github.com/roc-lang/unicode/releases/download/0.1.2/vH5iqn04ShmqP-pNemgF773f86COePSqMWHzVGrAKNo.tar.br",
 }
 
 import pf.Task exposing [Task]


### PR DESCRIPTION
This removes `<-` backpassing warnings, and removes the need for a special case for empty strings in the `reverse-string` exercise since `Grapheme.split` now handles empty strings correctly.