### PR TITLE
Upgrade imclerran/roc-isodate package to 0.5.0

### DIFF
--- a/config/generator_macros.j2
+++ b/config/generator_macros.j2
@@ -24,7 +24,7 @@ app [main] {
     {% if name == "unicode" -%}
     unicode: "https://github.com/roc-lang/unicode/releases/download/0.1.2/vH5iqn04ShmqP-pNemgF773f86COePSqMWHzVGrAKNo.tar.br"
     {%- elif name == "isodate" -%}
-    isodate: "https://github.com/imclerran/roc-isodate/releases/download/v0.4.1/OQwyjDUYQkmGRiaISkzBcw5dpnbi1OHi8KUDl7NZmC8.tar.br"
+    isodate: "https://github.com/imclerran/roc-isodate/releases/download/v0.5.0/ptg0ElRLlIqsxMDZTTvQHgUSkNrUSymQaGwTfv0UEmk.tar.br"
     {%- endif -%}
 {%- endfor -%}
 {%- endif %}

--- a/exercises/practice/gigasecond/gigasecond-test.roc
+++ b/exercises/practice/gigasecond/gigasecond-test.roc
@@ -3,7 +3,7 @@
 # File last updated on 2024-08-25
 app [main] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.14.0/dC5ceT962N_4jmoyoffVdphJ_4GlW3YMhAPyGPr-nU0.tar.br",
-    isodate: "https://github.com/imclerran/roc-isodate/releases/download/v0.4.1/OQwyjDUYQkmGRiaISkzBcw5dpnbi1OHi8KUDl7NZmC8.tar.br",
+    isodate: "https://github.com/imclerran/roc-isodate/releases/download/v0.5.0/ptg0ElRLlIqsxMDZTTvQHgUSkNrUSymQaGwTfv0UEmk.tar.br",
 }
 
 import pf.Task exposing [Task]


### PR DESCRIPTION
This update gets rid of peksy deprecation warnings regarding the `<-` backpassing syntax, following https://github.com/imclerran/roc-isodate/pull/25