### PR TITLE
Add error handling to the collatz-conjecture exercise

### DIFF
--- a/exercises/practice/collatz-conjecture/.meta/Example.roc
+++ b/exercises/practice/collatz-conjecture/.meta/Example.roc
@@ -1,10 +1,11 @@
 module [steps]
 
 steps = \n ->
-    if n == 1 then
-        0
+    if n <= 0 then
+        Err "Only positive integers are allowed"
+    else if n == 1 then
+        Ok 0
     else if Num.isEven n then
-        (steps (n // 2)) + 1
+        Ok ((steps? (n // 2)) + 1)
     else
-        (steps (3 * n + 1)) + 1
-
+        Ok ((steps? (3 * n + 1)) + 1)

--- a/exercises/practice/collatz-conjecture/.meta/template.j2
+++ b/exercises/practice/collatz-conjecture/.meta/template.j2
@@ -6,6 +6,10 @@ import {{ exercise | to_pascal }} exposing [steps]
 
 {% for case in cases -%}
 # {{ case["description"] }}
-expect {{ case["property"] | to_camel }} {{ case["input"]["number"] }} == {{ case["expected"] }}
+{% if case["expected"]["error"] -%}
+expect {{ case["property"] | to_camel }} {{ case["input"]["number"] }} == Err {{ case["expected"]["error"] | to_roc }}
+{%- else -%}
+expect {{ case["property"] | to_camel }} {{ case["input"]["number"] }} == Ok {{ case["expected"] }}
+{%- endif %}
 
 {% endfor %}

--- a/exercises/practice/collatz-conjecture/.meta/tests.toml
+++ b/exercises/practice/collatz-conjecture/.meta/tests.toml
@@ -28,7 +28,6 @@ include = false
 [2187673d-77d6-4543-975e-66df6c50e2da]
 description = "zero is an error"
 reimplements = "7d4750e6-def9-4b86-aec7-9f7eb44f95a3"
-include = false
 
 [c6c795bf-a288-45e9-86a1-841359ad426d]
 description = "negative value is an error"
@@ -37,4 +36,3 @@ include = false
 [ec11f479-56bc-47fd-a434-bcd7a31a7a2e]
 description = "negative value is an error"
 reimplements = "c6c795bf-a288-45e9-86a1-841359ad426d"
-include = false

--- a/exercises/practice/collatz-conjecture/collatz-conjecture-test.roc
+++ b/exercises/practice/collatz-conjecture/collatz-conjecture-test.roc
@@ -1,7 +1,9 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/collatz-conjecture/canonical-data.json
-# File last updated on 2024-08-24
-app [main] { pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.14.0/dC5ceT962N_4jmoyoffVdphJ_4GlW3YMhAPyGPr-nU0.tar.br" }
+# File last updated on 2024-08-27
+app [main] {
+    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.14.0/dC5ceT962N_4jmoyoffVdphJ_4GlW3YMhAPyGPr-nU0.tar.br",
+}
 
 import pf.Task exposing [Task]
 
@@ -11,14 +13,20 @@ main =
 import CollatzConjecture exposing [steps]
 
 # zero steps for one
-expect steps 1 == 0
+expect steps 1 == Ok 0
 
 # divide if even
-expect steps 16 == 4
+expect steps 16 == Ok 4
 
 # even and odd steps
-expect steps 12 == 9
+expect steps 12 == Ok 9
 
 # large number of even and odd steps
-expect steps 1000000 == 152
+expect steps 1000000 == Ok 152
+
+# zero is an error
+expect steps 0 == Err "Only positive integers are allowed"
+
+# negative value is an error
+expect steps -15 == Err "Only positive integers are allowed"
 


### PR DESCRIPTION
The tests now expect either `Ok 123` or `Err "error message"`, and I updated the `Example.roc` code accordingly.