### PR TITLE
Add anagram exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -234,7 +234,7 @@
         "uuid": "40942be8-7c32-4da3-acff-a2365087cd5d",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 1
+        "difficulty": 3
       }
     ]
   },

--- a/config.json
+++ b/config.json
@@ -227,6 +227,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2
+      },
+      {
+        "slug": "anagram",
+        "name": "Anagram",
+        "uuid": "40942be8-7c32-4da3-acff-a2365087cd5d",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1
       }
     ]
   },

--- a/exercises/practice/anagram/.docs/instructions.md
+++ b/exercises/practice/anagram/.docs/instructions.md
@@ -1,0 +1,13 @@
+# Instructions
+
+Your task is to, given a target word and a set of candidate words, to find the subset of the candidates that are anagrams of the target.
+
+An anagram is a rearrangement of letters to form a new word: for example `"owns"` is an anagram of `"snow"`.
+A word is _not_ its own anagram: for example, `"stop"` is not an anagram of `"stop"`.
+
+The target and candidates are words of one or more ASCII alphabetic characters (`A`-`Z` and `a`-`z`).
+Lowercase and uppercase characters are equivalent: for example, `"PoTS"` is an anagram of `"sTOp"`, but `StoP` is not an anagram of `sTOp`.
+The anagram set is the subset of the candidate set that are anagrams of the target (in any order).
+Words in the anagram set should have the same letter case as in the candidate set.
+
+Given the target `"stone"` and candidates `"stone"`, `"tones"`, `"banana"`, `"tons"`, `"notes"`, `"Seton"`, the anagram set is `"tones"`, `"notes"`, `"Seton"`.

--- a/exercises/practice/anagram/.docs/introduction.md
+++ b/exercises/practice/anagram/.docs/introduction.md
@@ -1,0 +1,12 @@
+# Introduction
+
+At a garage sale, you find a lovely vintage typewriter at a bargain price!
+Excitedly, you rush home, insert a sheet of paper, and start typing away.
+However, your excitement wanes when you examine the output: all words are garbled!
+For example, it prints "stop" instead of "post" and "least" instead of "stale."
+Carefully, you try again, but now it prints "spot" and "slate."
+After some experimentation, you find there is a random delay before each letter is printed, which messes up the order.
+You now understand why they sold it for so little money!
+
+You realize this quirk allows you to generate anagrams, which are words formed by rearranging the letters of another word.
+Pleased with your finding, you spend the rest of the day generating hundreds of anagrams.

--- a/exercises/practice/anagram/.meta/Example.roc
+++ b/exercises/practice/anagram/.meta/Example.roc
@@ -1,0 +1,46 @@
+module [findAnagrams]
+
+import unicode.Grapheme
+
+toUpper = \text ->
+    text
+    |> Str.toUtf8
+    |> List.map \c ->
+        if c >= 'a' && c <= 'z' then
+            c - 'a' + 'A'
+        else
+            c
+    |> Str.fromUtf8
+    |> Result.withDefault "Unreachable"
+
+compareGraphemes = \g1, g2 ->
+    s1 = g1 |> Str.toUtf8
+    s2 = g2 |> Str.toUtf8
+    cmp =
+        List.map2 s1 s2 \b1, b2 -> (b1, b2)
+        |> List.walkUntil EQ \_, (b1, b2) ->
+            if b1 == b2 then
+                Continue EQ
+            else if b1 < b2 then
+                Break LT
+            else
+                Break GT
+    if cmp == EQ then
+        Num.compare (List.len s1) (List.len s2)
+    else
+        cmp
+
+sortedGraphemes = \word ->
+    graphemes = word |> Grapheme.split?
+    graphemes |> List.sortWith compareGraphemes |> Ok
+
+isAnagramOf = \word1, word2 ->
+    sorted1 = word1 |> toUpper |> sortedGraphemes?
+    sorted2 = word2 |> toUpper |> sortedGraphemes?
+    Ok (sorted1 == sorted2)
+
+findAnagrams = \subject, candidates ->
+    candidates
+    |> List.dropIf \word -> toUpper word == toUpper subject
+    |> List.keepIf \word ->
+        word |> isAnagramOf subject |> Result.withDefault Bool.false

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "ageron"
+  ],
+  "files": {
+    "solution": [
+      "Anagram.roc"
+    ],
+    "test": [
+      "anagram-test.roc"
+    ],
+    "example": [
+      ".meta/Example.roc"
+    ]
+  },
+  "blurb": "Given a word and a list of possible anagrams, select the correct sublist.",
+  "source": "Inspired by the Extreme Startup game",
+  "source_url": "https://github.com/rchatley/extreme_startup"
+}

--- a/exercises/practice/anagram/.meta/template.j2
+++ b/exercises/practice/anagram/.meta/template.j2
@@ -1,0 +1,13 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+{{ macros.header(imports=["unicode"]) }}
+
+import {{ exercise | to_pascal }} exposing [{{ cases[0]["property"] | to_camel }}]
+
+{% for case in cases -%}
+# {{ case["description"] }}
+expect
+    result = {{ case["property"] | to_camel }} {{ case["input"]["subject"] | to_roc }} {{ case["input"]["candidates"] | to_roc }}
+    result == {{ case["expected"] | to_roc }}
+
+{% endfor %}

--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -1,0 +1,87 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[dd40c4d2-3c8b-44e5-992a-f42b393ec373]
+description = "no matches"
+
+[b3cca662-f50a-489e-ae10-ab8290a09bdc]
+description = "detects two anagrams"
+include = false
+
+[03eb9bbe-8906-4ea0-84fa-ffe711b52c8b]
+description = "detects two anagrams"
+reimplements = "b3cca662-f50a-489e-ae10-ab8290a09bdc"
+
+[a27558ee-9ba0-4552-96b1-ecf665b06556]
+description = "does not detect anagram subsets"
+
+[64cd4584-fc15-4781-b633-3d814c4941a4]
+description = "detects anagram"
+
+[99c91beb-838f-4ccd-b123-935139917283]
+description = "detects three anagrams"
+
+[78487770-e258-4e1f-a646-8ece10950d90]
+description = "detects multiple anagrams with different case"
+
+[1d0ab8aa-362f-49b7-9902-3d0c668d557b]
+description = "does not detect non-anagrams with identical checksum"
+
+[9e632c0b-c0b1-4804-8cc1-e295dea6d8a8]
+description = "detects anagrams case-insensitively"
+
+[b248e49f-0905-48d2-9c8d-bd02d8c3e392]
+description = "detects anagrams using case-insensitive subject"
+
+[f367325c-78ec-411c-be76-e79047f4bd54]
+description = "detects anagrams using case-insensitive possible matches"
+
+[7cc195ad-e3c7-44ee-9fd2-d3c344806a2c]
+description = "does not detect an anagram if the original word is repeated"
+include = false
+
+[630abb71-a94e-4715-8395-179ec1df9f91]
+description = "does not detect an anagram if the original word is repeated"
+reimplements = "7cc195ad-e3c7-44ee-9fd2-d3c344806a2c"
+
+[9878a1c9-d6ea-4235-ae51-3ea2befd6842]
+description = "anagrams must use all letters exactly once"
+
+[85757361-4535-45fd-ac0e-3810d40debc1]
+description = "words are not anagrams of themselves (case-insensitive)"
+include = false
+
+[68934ed0-010b-4ef9-857a-20c9012d1ebf]
+description = "words are not anagrams of themselves"
+reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
+
+[589384f3-4c8a-4e7d-9edc-51c3e5f0c90e]
+description = "words are not anagrams of themselves even if letter case is partially different"
+reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
+
+[ba53e423-7e02-41ee-9ae2-71f91e6d18e6]
+description = "words are not anagrams of themselves even if letter case is completely different"
+reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
+
+[a0705568-628c-4b55-9798-82e4acde51ca]
+description = "words other than themselves can be anagrams"
+include = false
+
+[33d3f67e-fbb9-49d3-a90e-0beb00861da7]
+description = "words other than themselves can be anagrams"
+reimplements = "a0705568-628c-4b55-9798-82e4acde51ca"
+
+[a6854f66-eec1-4afd-a137-62ef2870c051]
+description = "handles case of greek letters"
+include = false
+
+[fd3509e5-e3ba-409d-ac3d-a9ac84d13296]
+description = "different characters may have the same bytes"

--- a/exercises/practice/anagram/Anagram.roc
+++ b/exercises/practice/anagram/Anagram.roc
@@ -1,0 +1,8 @@
+module [findAnagrams]
+
+findAnagrams = \subject, candidates ->
+    crash "Please implement the 'findAnagrams' function"
+
+# HINT: we have added the `unicode` package to the app's header in
+#       anagram-test.roc, so you can use it here if you need to.
+#       For example, you could import unicode.Grapheme, just sayin'.

--- a/exercises/practice/anagram/anagram-test.roc
+++ b/exercises/practice/anagram/anagram-test.roc
@@ -1,0 +1,100 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/anagram/canonical-data.json
+# File last updated on 2024-08-27
+app [main] {
+    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.14.0/dC5ceT962N_4jmoyoffVdphJ_4GlW3YMhAPyGPr-nU0.tar.br",
+    unicode: "https://github.com/roc-lang/unicode/releases/download/0.1.2/vH5iqn04ShmqP-pNemgF773f86COePSqMWHzVGrAKNo.tar.br",
+}
+
+import pf.Task exposing [Task]
+
+main =
+    Task.ok {}
+
+import Anagram exposing [findAnagrams]
+
+# no matches
+expect
+    result = findAnagrams "diaper" ["hello", "world", "zombies", "pants"]
+    result == []
+
+# detects two anagrams
+expect
+    result = findAnagrams "solemn" ["lemons", "cherry", "melons"]
+    result == ["lemons", "melons"]
+
+# does not detect anagram subsets
+expect
+    result = findAnagrams "good" ["dog", "goody"]
+    result == []
+
+# detects anagram
+expect
+    result = findAnagrams "listen" ["enlists", "google", "inlets", "banana"]
+    result == ["inlets"]
+
+# detects three anagrams
+expect
+    result = findAnagrams "allergy" ["gallery", "ballerina", "regally", "clergy", "largely", "leading"]
+    result == ["gallery", "regally", "largely"]
+
+# detects multiple anagrams with different case
+expect
+    result = findAnagrams "nose" ["Eons", "ONES"]
+    result == ["Eons", "ONES"]
+
+# does not detect non-anagrams with identical checksum
+expect
+    result = findAnagrams "mass" ["last"]
+    result == []
+
+# detects anagrams case-insensitively
+expect
+    result = findAnagrams "Orchestra" ["cashregister", "Carthorse", "radishes"]
+    result == ["Carthorse"]
+
+# detects anagrams using case-insensitive subject
+expect
+    result = findAnagrams "Orchestra" ["cashregister", "carthorse", "radishes"]
+    result == ["carthorse"]
+
+# detects anagrams using case-insensitive possible matches
+expect
+    result = findAnagrams "orchestra" ["cashregister", "Carthorse", "radishes"]
+    result == ["Carthorse"]
+
+# does not detect an anagram if the original word is repeated
+expect
+    result = findAnagrams "go" ["goGoGO"]
+    result == []
+
+# anagrams must use all letters exactly once
+expect
+    result = findAnagrams "tapper" ["patter"]
+    result == []
+
+# words are not anagrams of themselves
+expect
+    result = findAnagrams "BANANA" ["BANANA"]
+    result == []
+
+# words are not anagrams of themselves even if letter case is partially different
+expect
+    result = findAnagrams "BANANA" ["Banana"]
+    result == []
+
+# words are not anagrams of themselves even if letter case is completely different
+expect
+    result = findAnagrams "BANANA" ["banana"]
+    result == []
+
+# words other than themselves can be anagrams
+expect
+    result = findAnagrams "LISTEN" ["LISTEN", "Silent"]
+    result == ["Silent"]
+
+# different characters may have the same bytes
+expect
+    result = findAnagrams "a⬂" ["€a"]
+    result == []
+


### PR DESCRIPTION
This exercise is actually surprisingly tricky, because the roc-lang/unicode package does not yet implement sorting and changing the case. As a result, the hardest part was implementing these. I had to exclude the test case for Greek letters, or else the exercise would be a bit demotivating.

We might want to provide the functions for sorting and changing the case. Wdyt?