### PR TITLE
Add flatten-array exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -259,6 +259,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1
+      },
+      {
+        "slug": "flatten-array",
+        "name": "Flatten Array",
+        "uuid": "9962e586-f68f-40c8-8547-75cec77c0380",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1
       }
     ]
   },

--- a/exercises/practice/flatten-array/.docs/instructions.md
+++ b/exercises/practice/flatten-array/.docs/instructions.md
@@ -1,0 +1,11 @@
+# Instructions
+
+Take a nested list and return a single flattened list with all values except nil/null.
+
+The challenge is to take an arbitrarily-deep nested list-like structure and produce a flattened structure without any nil/null values.
+
+For example:
+
+input: [1,[2,3,null,4],[null],5]
+
+output: [1,2,3,4,5]

--- a/exercises/practice/flatten-array/.meta/Example.roc
+++ b/exercises/practice/flatten-array/.meta/Example.roc
@@ -1,0 +1,7 @@
+module [flatten]
+
+flatten = \array ->
+    when array is
+        NestedArray list -> list |> List.joinMap flatten
+        Value value -> [value]
+        Null -> []

--- a/exercises/practice/flatten-array/.meta/config.json
+++ b/exercises/practice/flatten-array/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "ageron"
+  ],
+  "files": {
+    "solution": [
+      "FlattenArray.roc"
+    ],
+    "test": [
+      "flatten-array-test.roc"
+    ],
+    "example": [
+      ".meta/Example.roc"
+    ]
+  },
+  "blurb": "Take a nested list and return a single list with all values except nil/null.",
+  "source": "Interview Question",
+  "source_url": "https://reference.wolfram.com/language/ref/Flatten.html"
+}

--- a/exercises/practice/flatten-array/.meta/plugins.py
+++ b/exercises/practice/flatten-array/.meta/plugins.py
@@ -1,0 +1,8 @@
+def to_nested(value, top_level=True):
+    if value is None:
+        return "Null"
+    elif isinstance(value, int):
+        return f"Value {value}"
+    else:
+        content = ", ".join([to_nested(elem, False) for elem in value])
+        return f"NestedArray [\n{content}]"

--- a/exercises/practice/flatten-array/.meta/template.j2
+++ b/exercises/practice/flatten-array/.meta/template.j2
@@ -1,0 +1,13 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+{{ macros.header() }}
+
+import {{ exercise | to_pascal }} exposing [{{ cases[0]["property"] | to_camel }}]
+
+{% for case in cases -%}
+# {{ case["description"] }}
+expect
+    result = {{ case["property"] | to_camel }} ({{ plugins.to_nested(case["input"]["array"]) }})
+    result == {{ case["expected"] | to_roc }}
+
+{% endfor %}

--- a/exercises/practice/flatten-array/.meta/tests.toml
+++ b/exercises/practice/flatten-array/.meta/tests.toml
@@ -1,0 +1,43 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[8c71dabd-da60-422d-a290-4a571471fb14]
+description = "empty"
+
+[d268b919-963c-442d-9f07-82b93f1b518c]
+description = "no nesting"
+
+[3f15bede-c856-479e-bb71-1684b20c6a30]
+description = "flattens a nested array"
+
+[c84440cc-bb3a-48a6-862c-94cf23f2815d]
+description = "flattens array with just integers present"
+
+[d3d99d39-6be5-44f5-a31d-6037d92ba34f]
+description = "5 level nesting"
+
+[d572bdba-c127-43ed-bdcd-6222ac83d9f7]
+description = "6 level nesting"
+
+[0705a8e5-dc86-4cec-8909-150c5e54fa9c]
+description = "null values are omitted from the final result"
+
+[c6cf26de-8ccd-4410-84bd-b9efd88fd2bc]
+description = "consecutive null values at the front of the list are omitted from the final result"
+
+[382c5242-587e-4577-b8ce-a5fb51e385a1]
+description = "consecutive null values in the middle of the list are omitted from the final result"
+
+[ef1d4790-1b1e-4939-a179-51ace0829dbd]
+description = "6 level nest list with null values"
+
+[85721643-705a-4150-93ab-7ae398e2942d]
+description = "all values in nested list are null"

--- a/exercises/practice/flatten-array/FlattenArray.roc
+++ b/exercises/practice/flatten-array/FlattenArray.roc
@@ -1,0 +1,4 @@
+module [flatten]
+
+flatten = \array ->
+    crash "Please implement the 'flatten' function"

--- a/exercises/practice/flatten-array/flatten-array-test.roc
+++ b/exercises/practice/flatten-array/flatten-array-test.roc
@@ -1,0 +1,218 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/flatten-array/canonical-data.json
+# File last updated on 2024-08-28
+app [main] {
+    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.14.0/dC5ceT962N_4jmoyoffVdphJ_4GlW3YMhAPyGPr-nU0.tar.br",
+}
+
+import pf.Task exposing [Task]
+
+main =
+    Task.ok {}
+
+import FlattenArray exposing [flatten]
+
+# empty
+expect
+    result = flatten
+        (
+            NestedArray [
+            ]
+        )
+    result == []
+
+# no nesting
+expect
+    result = flatten
+        (
+            NestedArray [
+                Value 0,
+                Value 1,
+                Value 2,
+            ]
+        )
+    result == [0, 1, 2]
+
+# flattens a nested array
+expect
+    result = flatten
+        (
+            NestedArray [
+                NestedArray [
+                    NestedArray [
+                    ],
+                ],
+            ]
+        )
+    result == []
+
+# flattens array with just integers present
+expect
+    result = flatten
+        (
+            NestedArray [
+                Value 1,
+                NestedArray [
+                    Value 2,
+                    Value 3,
+                    Value 4,
+                    Value 5,
+                    Value 6,
+                    Value 7,
+                ],
+                Value 8,
+            ]
+        )
+    result == [1, 2, 3, 4, 5, 6, 7, 8]
+
+# 5 level nesting
+expect
+    result = flatten
+        (
+            NestedArray [
+                Value 0,
+                Value 2,
+                NestedArray [
+                    NestedArray [
+                        Value 2,
+                        Value 3,
+                    ],
+                    Value 8,
+                    Value 100,
+                    Value 4,
+                    NestedArray [
+                        NestedArray [
+                            NestedArray [
+                                Value 50,
+                            ],
+                        ],
+                    ],
+                ],
+                Value -2,
+            ]
+        )
+    result == [0, 2, 2, 3, 8, 100, 4, 50, -2]
+
+# 6 level nesting
+expect
+    result = flatten
+        (
+            NestedArray [
+                Value 1,
+                NestedArray [
+                    Value 2,
+                    NestedArray [
+                        NestedArray [
+                            Value 3,
+                        ],
+                    ],
+                    NestedArray [
+                        Value 4,
+                        NestedArray [
+                            NestedArray [
+                                Value 5,
+                            ],
+                        ],
+                    ],
+                    Value 6,
+                    Value 7,
+                ],
+                Value 8,
+            ]
+        )
+    result == [1, 2, 3, 4, 5, 6, 7, 8]
+
+# null values are omitted from the final result
+expect
+    result = flatten
+        (
+            NestedArray [
+                Value 1,
+                Value 2,
+                Null,
+            ]
+        )
+    result == [1, 2]
+
+# consecutive null values at the front of the list are omitted from the final result
+expect
+    result = flatten
+        (
+            NestedArray [
+                Null,
+                Null,
+                Value 3,
+            ]
+        )
+    result == [3]
+
+# consecutive null values in the middle of the list are omitted from the final result
+expect
+    result = flatten
+        (
+            NestedArray [
+                Value 1,
+                Null,
+                Null,
+                Value 4,
+            ]
+        )
+    result == [1, 4]
+
+# 6 level nest list with null values
+expect
+    result = flatten
+        (
+            NestedArray [
+                Value 0,
+                Value 2,
+                NestedArray [
+                    NestedArray [
+                        Value 2,
+                        Value 3,
+                    ],
+                    Value 8,
+                    NestedArray [
+                        NestedArray [
+                            Value 100,
+                        ],
+                    ],
+                    Null,
+                    NestedArray [
+                        NestedArray [
+                            Null,
+                        ],
+                    ],
+                ],
+                Value -2,
+            ]
+        )
+    result == [0, 2, 2, 3, 8, 100, -2]
+
+# all values in nested list are null
+expect
+    result = flatten
+        (
+            NestedArray [
+                Null,
+                NestedArray [
+                    NestedArray [
+                        NestedArray [
+                            Null,
+                        ],
+                    ],
+                ],
+                Null,
+                Null,
+                NestedArray [
+                    NestedArray [
+                        Null,
+                        Null,
+                    ],
+                    Null,
+                ],
+                Null,
+            ]
+        )
+    result == []
+


### PR DESCRIPTION
This was a tricky one because:
* There's no `null` in Roc. So I used a `Null` tag.
* Nested arrays require tags as well. I used `NestedArray [...]` and `Value 123`.
* I had to write `.meta/plugins.py` to properly generate these nested arrays in Roc.

However, the solution was comparatively easy.