### PR TITLE
Replace `Err "Foo bar"` with `Err FooBar`

### DIFF
--- a/exercises/practice/collatz-conjecture/.meta/Example.roc
+++ b/exercises/practice/collatz-conjecture/.meta/Example.roc
@@ -2,7 +2,7 @@ module [steps]
 
 steps = \n ->
     if n <= 0 then
-        Err "Only positive integers are allowed"
+        Err OnlyPositiveIntegersAreAllowed
     else if n == 1 then
         Ok 0
     else if Num.isEven n then

--- a/exercises/practice/collatz-conjecture/.meta/template.j2
+++ b/exercises/practice/collatz-conjecture/.meta/template.j2
@@ -9,7 +9,7 @@ import {{ exercise | to_pascal }} exposing [steps]
 expect
     result = {{ case["property"] | to_camel }} {{ case["input"]["number"] }}
 {%- if case["expected"]["error"] %}
-    result == Err {{ case["expected"]["error"] | to_roc }}
+    result == Err {{ case["expected"]["error"] | to_pascal }}
 {%- else %}
     result == Ok {{ case["expected"] }}
 {%- endif %}

--- a/exercises/practice/collatz-conjecture/collatz-conjecture-test.roc
+++ b/exercises/practice/collatz-conjecture/collatz-conjecture-test.roc
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/collatz-conjecture/canonical-data.json
-# File last updated on 2024-08-27
+# File last updated on 2024-08-29
 app [main] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.14.0/dC5ceT962N_4jmoyoffVdphJ_4GlW3YMhAPyGPr-nU0.tar.br",
 }
@@ -35,10 +35,10 @@ expect
 # zero is an error
 expect
     result = steps 0
-    result == Err "Only positive integers are allowed"
+    result == Err OnlyPositiveIntegersAreAllowed
 
 # negative value is an error
 expect
     result = steps -15
-    result == Err "Only positive integers are allowed"
+    result == Err OnlyPositiveIntegersAreAllowed
 

--- a/exercises/practice/grains/.meta/Example.roc
+++ b/exercises/practice/grains/.meta/Example.roc
@@ -5,7 +5,7 @@ grainsOnSquare = \square ->
         2 |> Num.powInt (square - 1) |> Ok
         # or: 1u64 |> Num.shiftLeftBy (square - 1) |> Ok
     else
-        Err "square must be between 1 and 64"
+        Err SquareMustBeBetween1And64
 
 totalGrains =
     Num.maxU64

--- a/exercises/practice/grains/.meta/template.j2
+++ b/exercises/practice/grains/.meta/template.j2
@@ -18,7 +18,7 @@ expect
 expect
     result = grainsOnSquare {{ subcase["input"]["square"] | to_roc }}
 {%- if subcase["expected"]["error"] %}
-    result == Err {{ subcase["expected"]["error"] | to_roc }}
+    result == Err {{ subcase["expected"]["error"] | to_pascal }}
 {%- else %}
     result == Ok {{ subcase["expected"] }}
 {%- endif %}

--- a/exercises/practice/grains/grains-test.roc
+++ b/exercises/practice/grains/grains-test.roc
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/grains/canonical-data.json
-# File last updated on 2024-08-27
+# File last updated on 2024-08-29
 app [main] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.14.0/dC5ceT962N_4jmoyoffVdphJ_4GlW3YMhAPyGPr-nU0.tar.br",
 }
@@ -54,17 +54,17 @@ expect
 # square 0 is invalid
 expect
     result = grainsOnSquare 0
-    result == Err "square must be between 1 and 64"
+    result == Err SquareMustBeBetween1And64
 
 # negative square is invalid
 expect
     result = grainsOnSquare -1
-    result == Err "square must be between 1 and 64"
+    result == Err SquareMustBeBetween1And64
 
 # square greater than 64 is invalid
 expect
     result = grainsOnSquare 65
-    result == Err "square must be between 1 and 64"
+    result == Err SquareMustBeBetween1And64
 
 ##
 ## returns the total number of grains on the board

--- a/exercises/practice/luhn/luhn-test.roc
+++ b/exercises/practice/luhn/luhn-test.roc
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/luhn/canonical-data.json
-# File last updated on 2024-08-27
+# File last updated on 2024-08-29
 app [main] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.14.0/dC5ceT962N_4jmoyoffVdphJ_4GlW3YMhAPyGPr-nU0.tar.br",
 }
@@ -121,3 +121,4 @@ expect
 expect
     result = valid "59%59"
     result == Bool.false
+

--- a/exercises/practice/perfect-numbers/.meta/Example.roc
+++ b/exercises/practice/perfect-numbers/.meta/Example.roc
@@ -2,7 +2,7 @@ module [classify]
 
 aliquotSum = \number ->
     if number <= 0 then
-        Err "Classification is only possible for positive integers."
+        Err ClassificationIsOnlyPossibleForPositiveIntegers
     else if number == 1 then
         Ok 0 # edge case
     else

--- a/exercises/practice/perfect-numbers/.meta/template.j2
+++ b/exercises/practice/perfect-numbers/.meta/template.j2
@@ -14,7 +14,7 @@ import {{ exercise | to_pascal }} exposing [classify]
 expect
     result = {{ case["property"] | to_camel }} {{ case["input"]["number"] }}
 {%- if case["expected"]["error"] %}
-    result == Err {{ case["expected"]["error"] | to_roc }}
+    result == Err {{ case["expected"]["error"] | to_pascal }}
 {%- else %}
     result == Ok {{ case["expected"] | to_pascal }}
 {%- endif %}

--- a/exercises/practice/perfect-numbers/perfect-numbers-test.roc
+++ b/exercises/practice/perfect-numbers/perfect-numbers-test.roc
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/perfect-numbers/canonical-data.json
-# File last updated on 2024-08-27
+# File last updated on 2024-08-29
 app [main] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.14.0/dC5ceT962N_4jmoyoffVdphJ_4GlW3YMhAPyGPr-nU0.tar.br",
 }
@@ -86,10 +86,10 @@ expect
 # Zero is rejected (as it is not a positive integer)
 expect
     result = classify 0
-    result == Err "Classification is only possible for positive integers."
+    result == Err ClassificationIsOnlyPossibleForPositiveIntegers
 
 # Negative integer is rejected (as it is not a positive integer)
 expect
     result = classify -1
-    result == Err "Classification is only possible for positive integers."
+    result == Err ClassificationIsOnlyPossibleForPositiveIntegers
 


### PR DESCRIPTION
AFAIU, using tags in errors is more idiomatic than using strings.