### PR TITLE
Add annotations for the main function(s) of every exercises

### DIFF
--- a/exercises/practice/anagram/.meta/Example.roc
+++ b/exercises/practice/anagram/.meta/Example.roc
@@ -39,6 +39,7 @@ isAnagramOf = \word1, word2 ->
     sorted2 = word2 |> toUpper |> sortedGraphemes?
     Ok (sorted1 == sorted2)
 
+findAnagrams : Str, List Str -> List Str
 findAnagrams = \subject, candidates ->
     candidates
     |> List.dropIf \word -> toUpper word == toUpper subject

--- a/exercises/practice/anagram/Anagram.roc
+++ b/exercises/practice/anagram/Anagram.roc
@@ -1,5 +1,6 @@
 module [findAnagrams]
 
+findAnagrams : Str, List Str -> List Str
 findAnagrams = \subject, candidates ->
     crash "Please implement the 'findAnagrams' function"
 

--- a/exercises/practice/armstrong-numbers/.meta/Example.roc
+++ b/exercises/practice/armstrong-numbers/.meta/Example.roc
@@ -6,6 +6,7 @@ listDigits = \number ->
     else
         (listDigits (number // 10)) |> List.append (number % 10)
 
+isArmstrongNumber : U64 -> Bool
 isArmstrongNumber = \number ->
     digits = listDigits number
     len = List.len digits

--- a/exercises/practice/armstrong-numbers/ArmstrongNumbers.roc
+++ b/exercises/practice/armstrong-numbers/ArmstrongNumbers.roc
@@ -1,4 +1,5 @@
 module [isArmstrongNumber]
 
+isArmstrongNumber : U64 -> Bool
 isArmstrongNumber = \number ->
     crash "Please implement the 'isArmstrongNumber' function"

--- a/exercises/practice/binary-search/.meta/Example.roc
+++ b/exercises/practice/binary-search/.meta/Example.roc
@@ -1,5 +1,6 @@
 module [find]
 
+find : List U64, U64 -> Result U64 [ValueNotInArray]
 find = \array, value ->
     binarySearch = \minIndex, maxIndex ->
         middleIndex = (minIndex + maxIndex) // 2

--- a/exercises/practice/binary-search/.meta/template.j2
+++ b/exercises/practice/binary-search/.meta/template.j2
@@ -9,7 +9,7 @@ import {{ exercise | to_pascal }} exposing [{{ cases[0]["property"] | to_camel }
 expect
     result = {{ case["input"]["array"] | to_roc }} |> {{ case["property"] | to_camel }} {{ case["input"]["value"] }}
 {%- if case["expected"]["error"] %}
-    result == Err {{ case["expected"]["error"] | to_pascal }}
+    Result.isErr result
 {%- else %}
     result == Ok {{ case["expected"] }}
 {%- endif %}

--- a/exercises/practice/binary-search/BinarySearch.roc
+++ b/exercises/practice/binary-search/BinarySearch.roc
@@ -1,5 +1,5 @@
 module [find]
 
-find : List U64, U64 -> Result U64 [ValueNotInArray]
+find : List U64, U64 -> Result U64 _
 find = \array, value ->
     crash "Please implement the 'find' function"

--- a/exercises/practice/binary-search/BinarySearch.roc
+++ b/exercises/practice/binary-search/BinarySearch.roc
@@ -1,4 +1,5 @@
 module [find]
 
+find : List U64, U64 -> Result U64 [ValueNotInArray]
 find = \array, value ->
     crash "Please implement the 'find' function"

--- a/exercises/practice/binary-search/binary-search-test.roc
+++ b/exercises/practice/binary-search/binary-search-test.roc
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/binary-search/canonical-data.json
-# File last updated on 2024-08-29
+# File last updated on 2024-09-03
 app [main] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br",
 }
@@ -43,25 +43,25 @@ expect
 # identifies that a value is not included in the array
 expect
     result = [1, 3, 4, 6, 8, 9, 11] |> find 7
-    result == Err ValueNotInArray
+    Result.isErr result
 
 # a value smaller than the array's smallest value is not found
 expect
     result = [1, 3, 4, 6, 8, 9, 11] |> find 0
-    result == Err ValueNotInArray
+    Result.isErr result
 
 # a value larger than the array's largest value is not found
 expect
     result = [1, 3, 4, 6, 8, 9, 11] |> find 13
-    result == Err ValueNotInArray
+    Result.isErr result
 
 # nothing is found in an empty array
 expect
     result = [] |> find 1
-    result == Err ValueNotInArray
+    Result.isErr result
 
 # nothing is found when the left and right bounds cross
 expect
     result = [1, 2] |> find 0
-    result == Err ValueNotInArray
+    Result.isErr result
 

--- a/exercises/practice/bob/.meta/Example.roc
+++ b/exercises/practice/bob/.meta/Example.roc
@@ -11,6 +11,7 @@ isYelling = \heyBob ->
     chars = Str.toUtf8 heyBob
     (chars |> List.any isUpper) && !(chars |> List.any isLower)
 
+response : Str -> Str
 response = \heyBob ->
     trimmed = Str.trim heyBob
     if trimmed == "" then

--- a/exercises/practice/bob/Bob.roc
+++ b/exercises/practice/bob/Bob.roc
@@ -1,4 +1,5 @@
 module [response]
 
+response : Str -> Str
 response = \heyBob ->
     crash "Please implement the `response` function"

--- a/exercises/practice/collatz-conjecture/.meta/Example.roc
+++ b/exercises/practice/collatz-conjecture/.meta/Example.roc
@@ -1,11 +1,12 @@
 module [steps]
 
-steps = \n ->
-    if n <= 0 then
-        Err OnlyPositiveIntegersAreAllowed
-    else if n == 1 then
+steps : U64 -> Result U64 [NumberArgWasZero]
+steps = \number ->
+    if number <= 0 then
+        Err NumberArgWasZero
+    else if number == 1 then
         Ok 0
-    else if Num.isEven n then
-        Ok ((steps? (n // 2)) + 1)
+    else if Num.isEven number then
+        Ok ((steps? (number // 2)) + 1)
     else
-        Ok ((steps? (3 * n + 1)) + 1)
+        Ok ((steps? (3 * number + 1)) + 1)

--- a/exercises/practice/collatz-conjecture/.meta/template.j2
+++ b/exercises/practice/collatz-conjecture/.meta/template.j2
@@ -9,7 +9,7 @@ import {{ exercise | to_pascal }} exposing [steps]
 expect
     result = {{ case["property"] | to_camel }} {{ case["input"]["number"] }}
 {%- if case["expected"]["error"] %}
-    result == Err NumberArgWasZero
+    Result.isErr result
 {%- else %}
     result == Ok {{ case["expected"] }}
 {%- endif %}

--- a/exercises/practice/collatz-conjecture/.meta/template.j2
+++ b/exercises/practice/collatz-conjecture/.meta/template.j2
@@ -9,7 +9,7 @@ import {{ exercise | to_pascal }} exposing [steps]
 expect
     result = {{ case["property"] | to_camel }} {{ case["input"]["number"] }}
 {%- if case["expected"]["error"] %}
-    result == Err {{ case["expected"]["error"] | to_pascal }}
+    result == Err NumberArgWasZero
 {%- else %}
     result == Ok {{ case["expected"] }}
 {%- endif %}

--- a/exercises/practice/collatz-conjecture/.meta/tests.toml
+++ b/exercises/practice/collatz-conjecture/.meta/tests.toml
@@ -36,3 +36,4 @@ include = false
 [ec11f479-56bc-47fd-a434-bcd7a31a7a2e]
 description = "negative value is an error"
 reimplements = "c6c795bf-a288-45e9-86a1-841359ad426d"
+include = false

--- a/exercises/practice/collatz-conjecture/CollatzConjecture.roc
+++ b/exercises/practice/collatz-conjecture/CollatzConjecture.roc
@@ -1,5 +1,5 @@
 module [steps]
 
-steps : U64 -> Result U64 [NumberArgWasZero]
+steps : U64 -> Result U64 _
 steps = \number ->
     crash "Please implement the `steps` function"

--- a/exercises/practice/collatz-conjecture/CollatzConjecture.roc
+++ b/exercises/practice/collatz-conjecture/CollatzConjecture.roc
@@ -1,4 +1,5 @@
 module [steps]
 
-steps = \n ->
+steps : U64 -> Result U64 [NumberArgWasZero]
+steps = \number ->
     crash "Please implement the `steps` function"

--- a/exercises/practice/collatz-conjecture/collatz-conjecture-test.roc
+++ b/exercises/practice/collatz-conjecture/collatz-conjecture-test.roc
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/collatz-conjecture/canonical-data.json
-# File last updated on 2024-09-02
+# File last updated on 2024-09-03
 app [main] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br",
 }
@@ -33,5 +33,5 @@ expect
 # zero is an error
 expect
     result = steps 0
-    result == Err NumberArgWasZero
+    Result.isErr result
 

--- a/exercises/practice/collatz-conjecture/collatz-conjecture-test.roc
+++ b/exercises/practice/collatz-conjecture/collatz-conjecture-test.roc
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/collatz-conjecture/canonical-data.json
-# File last updated on 2024-08-29
+# File last updated on 2024-09-02
 app [main] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br",
 }
@@ -33,10 +33,5 @@ expect
 # zero is an error
 expect
     result = steps 0
-    result == Err OnlyPositiveIntegersAreAllowed
-
-# negative value is an error
-expect
-    result = steps -15
-    result == Err OnlyPositiveIntegersAreAllowed
+    result == Err NumberArgWasZero
 

--- a/exercises/practice/darts/.meta/Example.roc
+++ b/exercises/practice/darts/.meta/Example.roc
@@ -3,6 +3,7 @@ module [score]
 distanceSquared = \x, y ->
     x * x + y * y
 
+score : F64, F64 -> U64
 score = \x, y ->
     d2 = distanceSquared x y
     if d2 > 100 then

--- a/exercises/practice/darts/Darts.roc
+++ b/exercises/practice/darts/Darts.roc
@@ -1,5 +1,6 @@
 module [score]
 
+score : F64, F64 -> U64
 score = \x, y ->
     crash "Please implement the `score` function"
 

--- a/exercises/practice/difference-of-squares/.meta/Example.roc
+++ b/exercises/practice/difference-of-squares/.meta/Example.roc
@@ -1,16 +1,19 @@
 module [squareOfSum, sumOfSquares, differenceOfSquares]
 
-sum = \n ->
-    n * (n + 1) / 2
+sum : U64 -> U64
+sum = \number ->
+    number * (number + 1) // 2
 
-squareOfSum = \n ->
-    s = sum n
+squareOfSum : U64 -> U64
+squareOfSum = \number ->
+    s = sum number
     s * s
 
-sumOfSquares = \n ->
-    s = sum n
-    s * (2 * n + 1) / 3
+sumOfSquares : U64 -> U64
+sumOfSquares = \number ->
+    s = sum number
+    s * (2 * number + 1) // 3
 
-differenceOfSquares = \n ->
-    (squareOfSum n) - (sumOfSquares n)
-
+differenceOfSquares : U64 -> U64
+differenceOfSquares = \number ->
+    (squareOfSum number) - (sumOfSquares number)

--- a/exercises/practice/difference-of-squares/DifferenceOfSquares.roc
+++ b/exercises/practice/difference-of-squares/DifferenceOfSquares.roc
@@ -1,10 +1,13 @@
 module [squareOfSum, sumOfSquares, differenceOfSquares]
 
-squareOfSum = \n ->
+squareOfSum : U64 -> U64
+squareOfSum = \number ->
     crash "Please implement the `squareOfSum` function"
 
-sumOfSquares = \n ->
+sumOfSquares : U64 -> U64
+sumOfSquares = \number ->
     crash "Please implement the `sumOfSquares` function"
 
-differenceOfSquares = \n ->
+differenceOfSquares : U64 -> U64
+differenceOfSquares = \number ->
     crash "Please implement the `differenceOfSquares` function"

--- a/exercises/practice/etl/.meta/Example.roc
+++ b/exercises/practice/etl/.meta/Example.roc
@@ -1,11 +1,13 @@
 module [transform]
 
+toLower : U8 -> U8
 toLower = \char ->
     if char >= 'A' && char <= 'Z' then
         char - 'A' + 'a'
     else
         char
 
+transform : Dict U64 (List U8) -> Dict U8 U64
 transform = \legacy ->
     legacy
     |> Dict.joinMap \score, letters ->

--- a/exercises/practice/etl/Etl.roc
+++ b/exercises/practice/etl/Etl.roc
@@ -1,4 +1,5 @@
 module [transform]
 
+transform : Dict U64 (List U8) -> Dict U8 U64
 transform = \legacy ->
     crash "Please implement the 'transform' function"

--- a/exercises/practice/flatten-array/.meta/Example.roc
+++ b/exercises/practice/flatten-array/.meta/Example.roc
@@ -1,6 +1,8 @@
 module [flatten]
 
-flatten : [NestedArray (List NestedValue), Null, Value I64] as NestedValue -> List I64
+NestedValue : [Value I64, Null, NestedArray (List NestedValue)]
+
+flatten : NestedValue -> List I64
 flatten = \array ->
     when array is
         NestedArray list -> list |> List.joinMap flatten

--- a/exercises/practice/flatten-array/.meta/Example.roc
+++ b/exercises/practice/flatten-array/.meta/Example.roc
@@ -1,5 +1,6 @@
 module [flatten]
 
+flatten : [NestedArray (List NestedValue), Null, Value I64] as NestedValue -> List I64
 flatten = \array ->
     when array is
         NestedArray list -> list |> List.joinMap flatten

--- a/exercises/practice/flatten-array/FlattenArray.roc
+++ b/exercises/practice/flatten-array/FlattenArray.roc
@@ -1,5 +1,7 @@
 module [flatten]
 
-flatten : [NestedArray (List NestedValue), Null, Value I64] as NestedValue -> List I64
+NestedValue : [Value I64, Null, NestedArray (List NestedValue)]
+
+flatten : NestedValue -> List I64
 flatten = \array ->
     crash "Please implement the 'flatten' function"

--- a/exercises/practice/flatten-array/FlattenArray.roc
+++ b/exercises/practice/flatten-array/FlattenArray.roc
@@ -1,4 +1,5 @@
 module [flatten]
 
+flatten : [NestedArray (List NestedValue), Null, Value I64] as NestedValue -> List I64
 flatten = \array ->
     crash "Please implement the 'flatten' function"

--- a/exercises/practice/gigasecond/Gigasecond.roc
+++ b/exercises/practice/gigasecond/Gigasecond.roc
@@ -1,4 +1,5 @@
 module [add]
 
+add : Str -> Str
 add = \moment ->
     crash "Please implement the 'add' function"

--- a/exercises/practice/grains/.meta/Example.roc
+++ b/exercises/practice/grains/.meta/Example.roc
@@ -1,18 +1,12 @@
 module [grainsOnSquare, totalGrains]
 
+grainsOnSquare : U8 -> Result U64 [SquareMustBeBetween1And64]
 grainsOnSquare = \square ->
     if square > 0 && square <= 64 then
-        2 |> Num.powInt (square - 1) |> Ok
-        # or: 1u64 |> Num.shiftLeftBy (square - 1) |> Ok
+        2u64 |> Num.powInt (Num.toU64 square - 1) |> Ok
     else
         Err SquareMustBeBetween1And64
 
+totalGrains : U64
 totalGrains =
     Num.maxU64
-# or: 0xFFFFFFFFFFFFFFFF
-# or: 2u128 |> Num.powInt 64 |> Num.sub 1
-# or: 1u128 |> Num.shiftLeftBy 64 |> Num.sub 1
-# or:
-#     List.range { start: At 1u64, end: At 64u64 }
-#     |> List.map \g -> grainsOnSquare g |> Result.withDefault 0
-#     |> List.sum

--- a/exercises/practice/grains/.meta/template.j2
+++ b/exercises/practice/grains/.meta/template.j2
@@ -18,7 +18,7 @@ expect
 expect
     result = grainsOnSquare {{ subcase["input"]["square"] | to_roc }}
 {%- if subcase["expected"]["error"] %}
-    result == Err {{ subcase["expected"]["error"] | to_pascal }}
+    Result.isErr result
 {%- else %}
     result == Ok {{ subcase["expected"] }}
 {%- endif %}

--- a/exercises/practice/grains/.meta/tests.toml
+++ b/exercises/practice/grains/.meta/tests.toml
@@ -35,6 +35,7 @@ description = "returns the number of grains on the square -> square 0 is invalid
 
 [61974483-eeb2-465e-be54-ca5dde366453]
 description = "returns the number of grains on the square -> negative square is invalid"
+include = false
 
 [a95e4374-f32c-45a7-a10d-ffec475c012f]
 description = "returns the number of grains on the square -> square greater than 64 is invalid"

--- a/exercises/practice/grains/Grains.roc
+++ b/exercises/practice/grains/Grains.roc
@@ -1,6 +1,6 @@
 module [grainsOnSquare, totalGrains]
 
-grainsOnSquare : U8 -> Result U64 [SquareMustBeBetween1And64]
+grainsOnSquare : U8 -> Result U64 _
 grainsOnSquare = \square ->
     crash "Please implement the 'grainsOnSquare' function"
 

--- a/exercises/practice/grains/Grains.roc
+++ b/exercises/practice/grains/Grains.roc
@@ -1,7 +1,9 @@
 module [grainsOnSquare, totalGrains]
 
+grainsOnSquare : U8 -> Result U64 [SquareMustBeBetween1And64]
 grainsOnSquare = \square ->
     crash "Please implement the 'grainsOnSquare' function"
 
+totalGrains : U64
 totalGrains =
     crash "Please implement the 'totalGrains' function"

--- a/exercises/practice/grains/grains-test.roc
+++ b/exercises/practice/grains/grains-test.roc
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/grains/canonical-data.json
-# File last updated on 2024-09-02
+# File last updated on 2024-09-03
 app [main] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br",
 }
@@ -52,12 +52,12 @@ expect
 # square 0 is invalid
 expect
     result = grainsOnSquare 0
-    result == Err SquareMustBeBetween1And64
+    Result.isErr result
 
 # square greater than 64 is invalid
 expect
     result = grainsOnSquare 65
-    result == Err SquareMustBeBetween1And64
+    Result.isErr result
 
 ##
 ## returns the total number of grains on the board

--- a/exercises/practice/grains/grains-test.roc
+++ b/exercises/practice/grains/grains-test.roc
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/grains/canonical-data.json
-# File last updated on 2024-08-29
+# File last updated on 2024-09-02
 app [main] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br",
 }
@@ -52,11 +52,6 @@ expect
 # square 0 is invalid
 expect
     result = grainsOnSquare 0
-    result == Err SquareMustBeBetween1And64
-
-# negative square is invalid
-expect
-    result = grainsOnSquare -1
     result == Err SquareMustBeBetween1And64
 
 # square greater than 64 is invalid

--- a/exercises/practice/hamming/.meta/template.j2
+++ b/exercises/practice/hamming/.meta/template.j2
@@ -9,7 +9,7 @@ import {{ exercise | to_pascal }} exposing [{{ cases[0]["property"] | to_camel }
 expect
     result = {{ case["property"] | to_camel }} {{ case["input"]["strand1"] | to_roc }} {{ case["input"]["strand2"] | to_roc }}
 {%- if case["expected"]["error"] %}
-    result == Err {{ case["expected"]["error"] | to_pascal }}
+    Result.isErr result
 {%- else %}
     result == Ok {{ case["expected"] }}
 {%- endif %}

--- a/exercises/practice/hamming/Hamming.roc
+++ b/exercises/practice/hamming/Hamming.roc
@@ -1,5 +1,5 @@
 module [distance]
 
-distance : Str, Str -> Result (Num *) [StrandsMustBeOfEqualLength]
+distance : Str, Str -> Result (Num *) _
 distance = \strand1, strand2 ->
     crash "Please implement the 'distance' function"

--- a/exercises/practice/hamming/Hamming.roc
+++ b/exercises/practice/hamming/Hamming.roc
@@ -1,4 +1,5 @@
 module [distance]
 
+distance : Str, Str -> Result (Num *) [StrandsMustBeOfEqualLength]
 distance = \strand1, strand2 ->
     crash "Please implement the 'distance' function"

--- a/exercises/practice/hamming/hamming-test.roc
+++ b/exercises/practice/hamming/hamming-test.roc
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/hamming/canonical-data.json
-# File last updated on 2024-08-28
+# File last updated on 2024-09-03
 app [main] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br",
 }
@@ -38,20 +38,20 @@ expect
 # disallow first strand longer
 expect
     result = distance "AATG" "AAA"
-    result == Err StrandsMustBeOfEqualLength
+    Result.isErr result
 
 # disallow second strand longer
 expect
     result = distance "ATA" "AGTG"
-    result == Err StrandsMustBeOfEqualLength
+    Result.isErr result
 
 # disallow empty first strand
 expect
     result = distance "" "G"
-    result == Err StrandsMustBeOfEqualLength
+    Result.isErr result
 
 # disallow empty second strand
 expect
     result = distance "G" ""
-    result == Err StrandsMustBeOfEqualLength
+    Result.isErr result
 

--- a/exercises/practice/hello-world/.meta/Example.roc
+++ b/exercises/practice/hello-world/.meta/Example.roc
@@ -1,3 +1,4 @@
 module [hello]
 
+hello : Str
 hello = "Hello, World!"

--- a/exercises/practice/hello-world/HelloWorld.roc
+++ b/exercises/practice/hello-world/HelloWorld.roc
@@ -1,3 +1,4 @@
 module [hello]
 
+hello : Str
 hello = "Goodbye, Mars!"

--- a/exercises/practice/house/.meta/Example.roc
+++ b/exercises/practice/house/.meta/Example.roc
@@ -23,6 +23,7 @@ verse = \index ->
         |> Str.joinWith " the "
     "This is the $(blablabla)"
 
+recite : U64, U64 -> Str
 recite = \startVerse, endVerse ->
     List.range { start: At startVerse, end: At endVerse }
     |> List.map verse

--- a/exercises/practice/house/House.roc
+++ b/exercises/practice/house/House.roc
@@ -1,4 +1,5 @@
 module [recite]
 
+recite : U64, U64 -> Str
 recite = \startVerse, endVerse ->
     crash "Please implement the 'recite' function"

--- a/exercises/practice/isbn-verifier/.meta/Example.roc
+++ b/exercises/practice/isbn-verifier/.meta/Example.roc
@@ -11,6 +11,7 @@ charValue = \char, index ->
     else
         Err InvalidIsbnBadChar
 
+isValid : Str -> Bool
 isValid = \isbn ->
     chars =
         isbn

--- a/exercises/practice/isbn-verifier/IsbnVerifier.roc
+++ b/exercises/practice/isbn-verifier/IsbnVerifier.roc
@@ -1,4 +1,5 @@
 module [isValid]
 
+isValid : Str -> Bool
 isValid = \isbn ->
     crash "Please implement the 'isValid' function"

--- a/exercises/practice/isogram/.meta/Example.roc
+++ b/exercises/practice/isogram/.meta/Example.roc
@@ -1,5 +1,6 @@
 module [isIsogram]
 
+isIsogram : Str -> Bool
 isIsogram = \phrase ->
     chars =
         phrase

--- a/exercises/practice/isogram/Isogram.roc
+++ b/exercises/practice/isogram/Isogram.roc
@@ -1,4 +1,5 @@
 module [isIsogram]
 
+isIsogram : Str -> Bool
 isIsogram = \phrase ->
     crash "Please implement the 'isIsogram' function"

--- a/exercises/practice/leap/.meta/Example.roc
+++ b/exercises/practice/leap/.meta/Example.roc
@@ -1,4 +1,5 @@
 module [isLeapYear]
 
+isLeapYear : I64 -> Bool
 isLeapYear = \year ->
     (year % 4 == 0) && (year % 400 == 0 || year % 100 != 0)

--- a/exercises/practice/leap/Leap.roc
+++ b/exercises/practice/leap/Leap.roc
@@ -1,4 +1,5 @@
 module [isLeapYear]
 
+isLeapYear : I64 -> Bool
 isLeapYear = \year ->
     crash "Please implement the `isLeapYear` function"

--- a/exercises/practice/list-ops/.meta/Example.roc
+++ b/exercises/practice/list-ops/.meta/Example.roc
@@ -1,16 +1,19 @@
 module [append, concat, filter, length, map, foldl, foldr, reverse]
 
+append : List a, List a -> List a
 append = \list1, list2 ->
     # Cheating: list1 |> List.concat list2
     when list1 is
         [] -> list2
         [first, .. as rest] -> (append rest list2) |> List.prepend first
 
+concat : List (List a) -> List a
 concat = \lists ->
     when lists is
         [] -> []
         [sublist1, .. as rest] -> sublist1 |> append (concat rest)
 
+filter : List a, (a -> Bool) -> List a
 filter = \list, function ->
     # Cheating: list |> List.keepIf function
     when list is
@@ -21,30 +24,35 @@ filter = \list, function ->
             else
                 filter rest function
 
+length : List a -> U64
 length = \list ->
     # Cheating: List.len list
     when list is
         [] -> 0
         [_, .. as rest] -> 1 + length rest
 
+map : List a, (a -> b) -> List b
 map = \list, function ->
     # Cheating: list |> List.map function
     when list is
         [] -> []
         [first, .. as rest] -> map rest function |> List.prepend (function first)
 
+foldl : List a, b, (b, a -> b) -> b
 foldl = \list, initial, function ->
     # Cheating: list |> List.walk initial function
     when list is
         [] -> initial
         [first, .. as rest] -> foldl rest (function initial first) function
 
+foldr : List a, b, (b, a -> b) -> b
 foldr = \list, initial, function ->
     # Cheating: list |> List.walkBackwards initial function
     when list is
         [] -> initial
         [.. as rest, last] -> foldr rest (function initial last) function
 
+reverse : List a -> List a
 reverse = \list ->
     # Cheating: List.reverse list
     when list is

--- a/exercises/practice/list-ops/ListOps.roc
+++ b/exercises/practice/list-ops/ListOps.roc
@@ -1,25 +1,33 @@
 module [append, concat, filter, length, map, foldl, foldr, reverse]
 
+append : List a, List a -> List a
 append = \list1, list2 ->
     crash "Please implement the 'append' function"
 
+concat : List (List a) -> List a
 concat = \lists ->
     crash "Please implement the 'concat' function"
 
+filter : List a, (a -> Bool) -> List a
 filter = \list, function ->
     crash "Please implement the 'filter' function"
 
+length : List a -> U64
 length = \list ->
     crash "Please implement the 'length' function"
 
+map : List a, (a -> b) -> List b
 map = \list, function ->
     crash "Please implement the 'map' function"
 
+foldl : List a, b, (b, a -> b) -> b
 foldl = \list, initial, function ->
     crash "Please implement the 'foldl' function"
 
+foldr : List a, b, (b, a -> b) -> b
 foldr = \list, initial, function ->
     crash "Please implement the 'foldr' function"
 
+reverse : List a -> List a
 reverse = \list ->
     crash "Please implement the 'reverse' function"

--- a/exercises/practice/luhn/.meta/Example.roc
+++ b/exercises/practice/luhn/.meta/Example.roc
@@ -12,7 +12,7 @@ valid = \number ->
 
         _ -> Bool.false
 
-toDigits : Str -> Result (List U16) _
+toDigits : Str -> Result (List U16) [IllegalCharacter]
 toDigits = \number ->
     help = \input, digits ->
         when input is

--- a/exercises/practice/minesweeper/Minesweeper.roc
+++ b/exercises/practice/minesweeper/Minesweeper.roc
@@ -1,4 +1,5 @@
 module [annotate]
 
+annotate : Str -> Str
 annotate = \minefield ->
     crash "Please implement the 'annotate' function"

--- a/exercises/practice/pangram/.meta/Example.roc
+++ b/exercises/practice/pangram/.meta/Example.roc
@@ -3,6 +3,7 @@ module [isPangram]
 alphabet =
     List.range { start: At 'A', end: At 'Z' } |> Set.fromList
 
+isPangram : Str -> Bool
 isPangram = \sentence ->
     sentence
     |> Str.toUtf8

--- a/exercises/practice/pangram/Pangram.roc
+++ b/exercises/practice/pangram/Pangram.roc
@@ -1,4 +1,5 @@
 module [isPangram]
 
+isPangram : Str -> Bool
 isPangram = \sentence ->
     crash "Please implement the 'isPangram' function"

--- a/exercises/practice/perfect-numbers/.meta/Example.roc
+++ b/exercises/practice/perfect-numbers/.meta/Example.roc
@@ -1,8 +1,9 @@
 module [classify]
 
+aliquotSum : U64 -> Result U64 [NumberArgIsZero]
 aliquotSum = \number ->
-    if number <= 0 then
-        Err OnlyPositiveIntegersAreAllowed
+    if number == 0 then
+        Err NumberArgIsZero
     else if number == 1 then
         Ok 0 # edge case
     else
@@ -14,6 +15,7 @@ aliquotSum = \number ->
                 |> List.sum
             )
 
+classify : U64 -> Result [Abundant, Deficient, Perfect] [NumberArgIsZero]
 classify = \number ->
     sum = aliquotSum? number
     if sum == number then

--- a/exercises/practice/perfect-numbers/.meta/template.j2
+++ b/exercises/practice/perfect-numbers/.meta/template.j2
@@ -14,7 +14,7 @@ import {{ exercise | to_pascal }} exposing [classify]
 expect
     result = {{ case["property"] | to_camel }} {{ case["input"]["number"] }}
 {%- if case["expected"]["error"] %}
-    result == Err NumberArgIsZero
+    Result.isErr result
 {%- else %}
     result == Ok {{ case["expected"] | to_pascal }}
 {%- endif %}

--- a/exercises/practice/perfect-numbers/.meta/template.j2
+++ b/exercises/practice/perfect-numbers/.meta/template.j2
@@ -14,7 +14,7 @@ import {{ exercise | to_pascal }} exposing [classify]
 expect
     result = {{ case["property"] | to_camel }} {{ case["input"]["number"] }}
 {%- if case["expected"]["error"] %}
-    result == Err OnlyPositiveIntegersAreAllowed
+    result == Err NumberArgIsZero
 {%- else %}
     result == Ok {{ case["expected"] | to_pascal }}
 {%- endif %}

--- a/exercises/practice/perfect-numbers/.meta/tests.toml
+++ b/exercises/practice/perfect-numbers/.meta/tests.toml
@@ -47,3 +47,4 @@ description = "Invalid inputs -> Zero is rejected (as it is not a positive integ
 
 [2d72ce2c-6802-49ac-8ece-c790ba3dae13]
 description = "Invalid inputs -> Negative integer is rejected (as it is not a positive integer)"
+include = false

--- a/exercises/practice/perfect-numbers/PerfectNumbers.roc
+++ b/exercises/practice/perfect-numbers/PerfectNumbers.roc
@@ -1,5 +1,5 @@
 module [classify]
 
-classify : U64 -> Result [Abundant, Deficient, Perfect] [NumberArgIsZero]
+classify : U64 -> Result [Abundant, Deficient, Perfect] _
 classify = \number ->
     crash "Please implement the 'classify' function"

--- a/exercises/practice/perfect-numbers/PerfectNumbers.roc
+++ b/exercises/practice/perfect-numbers/PerfectNumbers.roc
@@ -1,4 +1,5 @@
 module [classify]
 
+classify : U64 -> Result [Abundant, Deficient, Perfect] [NumberArgIsZero]
 classify = \number ->
     crash "Please implement the 'classify' function"

--- a/exercises/practice/perfect-numbers/perfect-numbers-test.roc
+++ b/exercises/practice/perfect-numbers/perfect-numbers-test.roc
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/perfect-numbers/canonical-data.json
-# File last updated on 2024-09-02
+# File last updated on 2024-09-03
 app [main] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br",
 }
@@ -84,5 +84,5 @@ expect
 # Zero is rejected (as it is not a positive integer)
 expect
     result = classify 0
-    result == Err NumberArgIsZero
+    Result.isErr result
 

--- a/exercises/practice/perfect-numbers/perfect-numbers-test.roc
+++ b/exercises/practice/perfect-numbers/perfect-numbers-test.roc
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/perfect-numbers/canonical-data.json
-# File last updated on 2024-08-29
+# File last updated on 2024-09-02
 app [main] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br",
 }
@@ -84,10 +84,5 @@ expect
 # Zero is rejected (as it is not a positive integer)
 expect
     result = classify 0
-    result == Err OnlyPositiveIntegersAreAllowed
-
-# Negative integer is rejected (as it is not a positive integer)
-expect
-    result = classify -1
-    result == Err OnlyPositiveIntegersAreAllowed
+    result == Err NumberArgIsZero
 

--- a/exercises/practice/raindrops/.meta/Example.roc
+++ b/exercises/practice/raindrops/.meta/Example.roc
@@ -1,5 +1,6 @@
 module [convert]
 
+convert : U64 -> Str
 convert = \number ->
     pling = if number % 3 == 0 then "Pling" else ""
     plang = if number % 5 == 0 then "Plang" else ""

--- a/exercises/practice/raindrops/Raindrops.roc
+++ b/exercises/practice/raindrops/Raindrops.roc
@@ -1,4 +1,5 @@
 module [convert]
 
+convert : U64 -> Str
 convert = \number ->
     crash "Please implement the 'convert' function"

--- a/exercises/practice/resistor-color-duo/.meta/Example.roc
+++ b/exercises/practice/resistor-color-duo/.meta/Example.roc
@@ -5,6 +5,7 @@ allColors = ["black", "brown", "red", "orange", "yellow", "green", "blue", "viol
 colorCode = \color ->
     allColors |> List.findFirstIndex \elem -> elem == color
 
+value : List Str -> Result U64 [NotFound, OutOfBounds]
 value = \colors ->
     first = colors |> List.get? 0 |> colorCode?
     second = colors |> List.get? 1 |> colorCode?

--- a/exercises/practice/resistor-color-duo/ResistorColorDuo.roc
+++ b/exercises/practice/resistor-color-duo/ResistorColorDuo.roc
@@ -1,4 +1,5 @@
 module [value]
 
+value : List Str -> Result U64 [NotFound, OutOfBounds]
 value = \colors ->
     crash "Please implement the 'value' function"

--- a/exercises/practice/resistor-color-duo/ResistorColorDuo.roc
+++ b/exercises/practice/resistor-color-duo/ResistorColorDuo.roc
@@ -1,5 +1,5 @@
 module [value]
 
-value : List Str -> Result U64 [NotFound, OutOfBounds]
+value : List Str -> Result U64 _
 value = \colors ->
     crash "Please implement the 'value' function"

--- a/exercises/practice/resistor-color/.meta/Example.roc
+++ b/exercises/practice/resistor-color/.meta/Example.roc
@@ -1,8 +1,10 @@
 module [colorCode, colorCodeFromDict, colors]
 
+colors : List Str
 colors =
     ["black", "brown", "red", "orange", "yellow", "green", "blue", "violet", "grey", "white"]
 
+colorCode : Str -> Result U64 [NotFound]
 colorCode = \color ->
     colors |> List.findFirstIndex \elem -> elem == color
 

--- a/exercises/practice/resistor-color/ResistorColor.roc
+++ b/exercises/practice/resistor-color/ResistorColor.roc
@@ -1,6 +1,6 @@
 module [colorCode, colors]
 
-colorCode : Str -> Result U64 [NotFound]
+colorCode : Str -> Result U64 _
 colorCode = \color ->
     crash "Please implement the 'colorCode' function"
 

--- a/exercises/practice/resistor-color/ResistorColor.roc
+++ b/exercises/practice/resistor-color/ResistorColor.roc
@@ -1,7 +1,9 @@
 module [colorCode, colors]
 
+colorCode : Str -> Result U64 [NotFound]
 colorCode = \color ->
     crash "Please implement the 'colorCode' function"
 
+colors : List Str
 colors =
     crash "Please implement the 'colors' function"

--- a/exercises/practice/reverse-string/.meta/Example.roc
+++ b/exercises/practice/reverse-string/.meta/Example.roc
@@ -11,6 +11,7 @@ import unicode.Grapheme
 ## Unicode codepoints (e + ´).
 ## To use the `unicode` package, its URL must be added to the app's header.
 ## Luckily, we've added it for you in reverse-string-test.roc. Take a look!
+reverse : Str -> Str
 reverse = \string ->
     when Grapheme.split string is
         Ok graphemes -> graphemes |> List.reverse |> Str.joinWith ""

--- a/exercises/practice/reverse-string/ReverseString.roc
+++ b/exercises/practice/reverse-string/ReverseString.roc
@@ -1,5 +1,6 @@
 module [reverse]
 
+reverse : Str -> Str
 reverse = \string ->
     crash "Please implement the `reverse` function"
 

--- a/exercises/practice/rna-transcription/.meta/Example.roc
+++ b/exercises/practice/rna-transcription/.meta/Example.roc
@@ -8,6 +8,7 @@ complement = \nucleotide ->
         'A' -> 'U'
         c -> c # invalid nucleotides are ignored
 
+toRna : Str -> Str
 toRna = \dna ->
     maybeRna =
         dna

--- a/exercises/practice/rna-transcription/RnaTranscription.roc
+++ b/exercises/practice/rna-transcription/RnaTranscription.roc
@@ -1,4 +1,5 @@
 module [toRna]
 
+toRna : Str -> Str
 toRna = \dna ->
     crash "Please implement the 'toRna' function"

--- a/exercises/practice/rotational-cipher/.meta/Example.roc
+++ b/exercises/practice/rotational-cipher/.meta/Example.roc
@@ -8,6 +8,7 @@ shiftChar = \c, shiftKey ->
     else
         c
 
+rotate : Str, U8 -> Str
 rotate = \text, shiftKey ->
     text
     |> Str.toUtf8

--- a/exercises/practice/rotational-cipher/RotationalCipher.roc
+++ b/exercises/practice/rotational-cipher/RotationalCipher.roc
@@ -1,4 +1,5 @@
 module [rotate]
 
+rotate : Str, U8 -> Str
 rotate = \text, shiftKey ->
     crash "Please implement the 'rotate' function"

--- a/exercises/practice/secret-handshake/.meta/Example.roc
+++ b/exercises/practice/secret-handshake/.meta/Example.roc
@@ -1,5 +1,6 @@
 module [commands]
 
+commands : U64 -> List Str
 commands = \number ->
     actions =
         [(1, "wink"), (2, "double blink"), (4, "close your eyes"), (8, "jump")]

--- a/exercises/practice/secret-handshake/SecretHandshake.roc
+++ b/exercises/practice/secret-handshake/SecretHandshake.roc
@@ -1,4 +1,5 @@
 module [commands]
 
+commands : U64 -> List Str
 commands = \number ->
     crash "Please implement the 'commands' function"

--- a/exercises/practice/space-age/.meta/Example.roc
+++ b/exercises/practice/space-age/.meta/Example.roc
@@ -4,6 +4,7 @@ round = \value, { digits ? 2 } ->
     pow = 10.0 |> Num.pow digits
     value * pow |> Num.round |> Num.toFrac |> Num.div pow
 
+age : Str, Dec -> Result Dec [NotAPlanet]
 age = \planet, seconds ->
     periodInEarthYears = orbitalPeriodInEarthYears? planet
     periodInSeconds = periodInEarthYears * 365.25 * 24 * 60 * 60

--- a/exercises/practice/space-age/.meta/template.j2
+++ b/exercises/practice/space-age/.meta/template.j2
@@ -9,7 +9,7 @@ import {{ exercise | to_pascal }} exposing [{{ cases[0]["property"] | to_camel }
 expect
     result = {{ case["property"] | to_camel }} {{ case["input"]["planet"] | to_roc }} {{ case["input"]["seconds"] }}
 {%- if case["expected"]["error"] %}
-    result == Err {{ case["expected"]["error"] | to_pascal }}
+    Result.isErr result
 {%- else %}
     result == Ok {{ case["expected"] }}
 {%- endif %}

--- a/exercises/practice/space-age/SpaceAge.roc
+++ b/exercises/practice/space-age/SpaceAge.roc
@@ -1,4 +1,5 @@
 module [age]
 
+age : Str, Dec -> Result Dec [NotAPlanet]
 age = \planet, seconds ->
     crash "Please implement the 'age' function"

--- a/exercises/practice/space-age/SpaceAge.roc
+++ b/exercises/practice/space-age/SpaceAge.roc
@@ -1,5 +1,5 @@
 module [age]
 
-age : Str, Dec -> Result Dec [NotAPlanet]
+age : Str, Dec -> Result Dec _
 age = \planet, seconds ->
     crash "Please implement the 'age' function"

--- a/exercises/practice/space-age/space-age-test.roc
+++ b/exercises/practice/space-age/space-age-test.roc
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/space-age/canonical-data.json
-# File last updated on 2024-08-29
+# File last updated on 2024-09-03
 app [main] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br",
 }
@@ -53,5 +53,5 @@ expect
 # invalid planet causes error
 expect
     result = age "Sun" 680804807
-    result == Err NotAPlanet
+    Result.isErr result
 

--- a/exercises/practice/square-root/.meta/Example.roc
+++ b/exercises/practice/square-root/.meta/Example.roc
@@ -1,5 +1,6 @@
 module [squareRoot, squareRootTheSimpleWay]
 
+squareRoot : U64 -> U64
 squareRoot = \radicand ->
     binarySearch = \min, max ->
         val = (min + max) // 2

--- a/exercises/practice/square-root/SquareRoot.roc
+++ b/exercises/practice/square-root/SquareRoot.roc
@@ -1,4 +1,5 @@
 module [squareRoot]
 
+squareRoot : U64 -> U64
 squareRoot = \radicand ->
     crash "Please implement the 'squareRoot' function"

--- a/exercises/practice/sum-of-multiples/.meta/Example.roc
+++ b/exercises/practice/sum-of-multiples/.meta/Example.roc
@@ -1,5 +1,6 @@
 module [sumOfMultiples]
 
+sumOfMultiples : List U64, U64 -> U64
 sumOfMultiples = \factors, limit ->
     factors
     |> List.keepIf \factor -> factor > 0

--- a/exercises/practice/sum-of-multiples/SumOfMultiples.roc
+++ b/exercises/practice/sum-of-multiples/SumOfMultiples.roc
@@ -1,4 +1,5 @@
 module [sumOfMultiples]
 
+sumOfMultiples : List U64, U64 -> U64
 sumOfMultiples = \factors, limit ->
     crash "Please implement the 'sumOfMultiples' function"

--- a/exercises/practice/triangle/.meta/Example.roc
+++ b/exercises/practice/triangle/.meta/Example.roc
@@ -6,11 +6,14 @@ approxEq = \x, y ->
 isValidTriangle = \(a, b, c) ->
     a > 0 && b > 0 && c > 0 && a + b >= c && a + c >= b && b + c >= a
 
+isEquilateral : (F64, F64, F64) -> Bool
 isEquilateral = \(a, b, c) ->
     isValidTriangle (a, b, c) && approxEq a b && approxEq b c
 
+isIsosceles : (F64, F64, F64) -> Bool
 isIsosceles = \(a, b, c) ->
     isValidTriangle (a, b, c) && (approxEq a b || approxEq b c || approxEq a c)
 
+isScalene : (F64, F64, F64) -> Bool
 isScalene = \(a, b, c) ->
     isValidTriangle (a, b, c) && !(isIsosceles (a, b, c))

--- a/exercises/practice/triangle/Triangle.roc
+++ b/exercises/practice/triangle/Triangle.roc
@@ -1,10 +1,13 @@
 module [isEquilateral, isIsosceles, isScalene]
 
+isEquilateral : (F64, F64, F64) -> Bool
 isEquilateral = \(a, b, c) ->
     crash "Please implement the 'isEquilateral' function"
 
+isIsosceles : (F64, F64, F64) -> Bool
 isIsosceles = \(a, b, c) ->
     crash "Please implement the 'isIsosceles' function"
 
+isScalene : (F64, F64, F64) -> Bool
 isScalene = \(a, b, c) ->
     crash "Please implement the 'isScalene' function"

--- a/exercises/practice/two-fer/.meta/Example.roc
+++ b/exercises/practice/two-fer/.meta/Example.roc
@@ -1,5 +1,6 @@
 module [twoFer]
 
+twoFer : [Name Str, Anonymous] -> Str
 twoFer = \name ->
     when name is
         Anonymous -> "One for you, one for me."

--- a/exercises/practice/two-fer/TwoFer.roc
+++ b/exercises/practice/two-fer/TwoFer.roc
@@ -1,4 +1,5 @@
 module [twoFer]
 
+twoFer : [Name Str, Anonymous] -> Str
 twoFer = \name ->
     crash "Please implement the 'twoFer' function"

--- a/exercises/practice/wordy/.meta/Example.roc
+++ b/exercises/practice/wordy/.meta/Example.roc
@@ -21,6 +21,7 @@ evaluateExpression = \accumulator, operations ->
         ["cubed"] -> Err UnknownOperation
         _ -> Err SyntaxError
 
+answer : Str -> Result I64 [UnknownOperation, SyntaxError]
 answer = \question ->
     words = question |> Str.replaceEach "?" " ?" |> Str.split " "
     when words is

--- a/exercises/practice/wordy/.meta/template.j2
+++ b/exercises/practice/wordy/.meta/template.j2
@@ -9,7 +9,7 @@ import {{ exercise | to_pascal }} exposing [answer]
 expect
     result = {{ case["property"] | to_camel }} {{ case["input"]["question"] | to_roc }}
 {%- if case["expected"]["error"] %}
-    result == Err {{ case["expected"]["error"] | to_pascal }}
+    Result.isErr result
 {%- else %}
     result == Ok {{ case["expected"] }}
 {%- endif %}

--- a/exercises/practice/wordy/Wordy.roc
+++ b/exercises/practice/wordy/Wordy.roc
@@ -1,5 +1,5 @@
 module [answer]
 
-answer : Str -> Result I64 [UnknownOperation, SyntaxError]
+answer : Str -> Result I64 _
 answer = \question ->
     crash "Please implement the 'answer' function"

--- a/exercises/practice/wordy/Wordy.roc
+++ b/exercises/practice/wordy/Wordy.roc
@@ -1,4 +1,5 @@
 module [answer]
 
+answer : Str -> Result I64 [UnknownOperation, SyntaxError]
 answer = \question ->
     crash "Please implement the 'answer' function"

--- a/exercises/practice/wordy/wordy-test.roc
+++ b/exercises/practice/wordy/wordy-test.roc
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/wordy/canonical-data.json
-# File last updated on 2024-08-27
+# File last updated on 2024-09-03
 app [main] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br",
 }
@@ -88,40 +88,40 @@ expect
 # unknown operation
 expect
     result = answer "What is 52 cubed?"
-    result == Err UnknownOperation
+    Result.isErr result
 
 # Non math question
 expect
     result = answer "Who is the President of the United States?"
-    result == Err UnknownOperation
+    Result.isErr result
 
 # reject problem missing an operand
 expect
     result = answer "What is 1 plus?"
-    result == Err SyntaxError
+    Result.isErr result
 
 # reject problem with no operands or operators
 expect
     result = answer "What is?"
-    result == Err SyntaxError
+    Result.isErr result
 
 # reject two operations in a row
 expect
     result = answer "What is 1 plus plus 2?"
-    result == Err SyntaxError
+    Result.isErr result
 
 # reject two numbers in a row
 expect
     result = answer "What is 1 plus 2 1?"
-    result == Err SyntaxError
+    Result.isErr result
 
 # reject postfix notation
 expect
     result = answer "What is 1 2 plus?"
-    result == Err SyntaxError
+    Result.isErr result
 
 # reject prefix notation
 expect
     result = answer "What is plus 1 2?"
-    result == Err SyntaxError
+    Result.isErr result
 


### PR DESCRIPTION
This PR adds annotations to the main function(s) of every exercise.

This includes all functions in the main file (e.g., `exercises/practice/leap/Leap.roc`) and the same functions in the example code (e.g., `exercises/practice/leap/.meta/Example.roc`) but I did not annotate other functions (yet?).

Also note that in some cases the annotations removed the need for some error test cases: I removed the test cases for negative inputs if the input is annotated as a positive integer like `U8` or `U64`.

Side note: I removed some commented-out code that was meant to show alternative ways of implementing things, because such code often ends up stale, plus the `Example.roc` file doesn't seem to appear anywhere on the website, it just looks like it's meant to ensure that the test cases work well.