### PR TITLE
Make the solution to the diamond exercise much more elegant

### DIFF
--- a/exercises/practice/diamond/.meta/Example.roc
+++ b/exercises/practice/diamond/.meta/Example.roc
@@ -1,30 +1,24 @@
 module [diamond]
 
-makeRow : U8, U8 -> Str
-makeRow = \rowIndex, numRows ->
-    middleRowIndex = numRows // 2
-    letterIndex =
-        if rowIndex > middleRowIndex then
-            numRows - rowIndex - 1
-        else
-            rowIndex
-    center =
-        if letterIndex == 0 then
-            ['A']
-        else
-            letter = letterIndex + 'A'
-            innerSpaces = List.repeat ' ' (2 * letterIndex - 1 |> Num.toU64)
-            [letter] |> List.concat innerSpaces |> List.append letter
+getChar : I8, I8, I8 -> U8
+getChar = \rowIndex, colIndex, letterIndex ->
+    if Num.abs rowIndex + Num.abs colIndex == letterIndex then
+        letterIndex - Num.abs rowIndex |> Num.toU8 |> Num.add 'A'
+    else
+        ' '
 
-    outerSpaces = List.repeat ' ' (middleRowIndex - letterIndex |> Num.toU64)
-    rowChars = outerSpaces |> List.concat center |> List.concat outerSpaces
-    when rowChars |> Str.fromUtf8 is
+unwrapFromUtf8 : List U8 -> Str
+unwrapFromUtf8 = \chars ->
+    when chars |> Str.fromUtf8 is
         Ok result -> result
-        Err _ -> crash "Unreachable: Str.fromUtf8 should never fail here"
+        Err _ -> crash "Str.fromUtf8 should never fail here"
 
 diamond : U8 -> Str
 diamond = \letter ->
-    numRows = 2 * (letter - 'A') + 1
-    List.range { start: At 0, end: Before numRows }
-    |> List.map \rowIndex -> makeRow rowIndex numRows
+    letterIndex = letter - 'A' |> Num.toI8
+    List.range { start: At -letterIndex, end: At letterIndex }
+    |> List.map \rowIndex ->
+        List.range { start: At -letterIndex, end: At letterIndex }
+        |> List.map \colIndex -> getChar rowIndex colIndex letterIndex
+        |> unwrapFromUtf8
     |> Str.joinWith "\n"


### PR DESCRIPTION
I wasn't satisfied with my previous solution to the diamond exercise, it does the job but it's long and ugly.
I had an aha moment when I woke up this morning: the perimeter of a circle is the set of points that are equidistant to the center when using the euclidean distance (i.e., the l<sub>2</sub> norm), and similarly, the perimeter of a diamond is the set of points that are equidistant to the center when using the manhattan distance (i.e., the l<sub>1</sub> norm). In other words, a point on the perimeter of a diamond of size `c` centered on (0, 0) is such that `|x| + |y| = c`.
This solution uses this fact, and I find it sooo much better than the previous one.
