### PR TITLE
Add rectangles exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -237,7 +237,7 @@
         "uuid": "2eb30b47-a1e0-44e5-bb22-6085a938ddb5",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 1
+        "difficulty": 3
       },
       {
         "slug": "reverse-string",

--- a/config.json
+++ b/config.json
@@ -232,6 +232,14 @@
         "difficulty": 3
       },
       {
+        "slug": "rectangles",
+        "name": "Rectangles",
+        "uuid": "2eb30b47-a1e0-44e5-bb22-6085a938ddb5",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 1
+      },
+      {
         "slug": "reverse-string",
         "name": "Reverse String",
         "uuid": "7bd2e210-08aa-45e9-8a19-f2213a22ac27",

--- a/exercises/practice/rectangles/.docs/instructions.md
+++ b/exercises/practice/rectangles/.docs/instructions.md
@@ -1,0 +1,63 @@
+# Instructions
+
+Count the rectangles in an ASCII diagram like the one below.
+
+```text
+   +--+
+  ++  |
++-++--+
+|  |  |
++--+--+
+```
+
+The above diagram contains these 6 rectangles:
+
+```text
+
+
++-----+
+|     |
++-----+
+```
+
+```text
+   +--+
+   |  |
+   |  |
+   |  |
+   +--+
+```
+
+```text
+   +--+
+   |  |
+   +--+
+
+
+```
+
+```text
+
+
+   +--+
+   |  |
+   +--+
+```
+
+```text
+
+
++--+
+|  |
++--+
+```
+
+```text
+
+  ++
+  ++
+
+
+```
+
+You may assume that the input is always a proper rectangle (i.e. the length of every line equals the length of the first line).

--- a/exercises/practice/rectangles/.meta/Example.roc
+++ b/exercises/practice/rectangles/.meta/Example.roc
@@ -1,0 +1,43 @@
+module [rectangles]
+
+## Is there a rectangle between the top left (x1, y1) corner and the bottom
+## right (x2, y2) corner.
+isRectangle : { grid : List (List U8), x1 : U64, y1 : U64, x2 : U64, y2 : U64 } -> Bool
+isRectangle = \{ grid, x1, y1, x2, y2 } ->
+    getCell = \(x, y) -> grid |> List.get? y |> List.get x
+    isCorner = \pos -> getCell pos == Ok '+'
+    isHorizontal = \pos -> isCorner pos || getCell pos == Ok '-'
+    isVertical = \pos -> isCorner pos || getCell pos == Ok '|'
+    hasHorizontalBorder = \y ->
+        List.range { start: At x1, end: At x2 }
+        |> List.all \x -> isHorizontal (x, y)
+    hasVerticalBorder = \x ->
+        List.range { start: At y1, end: At y2 }
+        |> List.all \y -> isVertical (x, y)
+    (
+        ([(x1, y1), (x2, y1), (x1, y2), (x2, y2)] |> List.all isCorner)
+        && ([y1, y2] |> List.all hasHorizontalBorder)
+        && ([x1, x2] |> List.all hasVerticalBorder)
+    )
+
+rectangles : Str -> U64
+rectangles = \diagram ->
+    grid =
+        diagram
+        |> Str.split "\n"
+        |> List.map Str.toUtf8
+    height = grid |> List.len
+    grid
+    |> List.mapWithIndex \row, y1 -> # number of rectangles with top on this row
+        row
+        |> List.mapWithIndex \_char, x1 -> # number with top-left on this column
+            List.range { start: After y1, end: Before height }
+            |> List.map \y2 -> # number of rectangles with bottom on this row
+                List.range { start: After x1, end: Before (List.len row) }
+                |> List.map \x2 -> # number with bottom-right on this column
+                    if isRectangle { grid, x1, y1, x2, y2 } then 1 else 0
+                |> List.sum
+            |> List.sum
+        |> List.sum
+    |> List.sum
+

--- a/exercises/practice/rectangles/.meta/config.json
+++ b/exercises/practice/rectangles/.meta/config.json
@@ -1,0 +1,17 @@
+{
+  "authors": [
+    "ageron"
+  ],
+  "files": {
+    "solution": [
+      "Rectangles.roc"
+    ],
+    "test": [
+      "rectangles-test.roc"
+    ],
+    "example": [
+      ".meta/Example.roc"
+    ]
+  },
+  "blurb": "Count the rectangles in an ASCII diagram."
+}

--- a/exercises/practice/rectangles/.meta/template.j2
+++ b/exercises/practice/rectangles/.meta/template.j2
@@ -1,0 +1,14 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+{{ macros.header() }}
+
+import {{ exercise | to_pascal }} exposing [{{ cases[0]["property"] | to_camel }}]
+
+{% for case in cases -%}
+# {{ case["description"] }}
+expect
+    result = {{ case["property"] | to_camel }} {{ case["input"]["strings"] | to_roc_multiline_string | indent(8) }}
+    result == {{ case["expected"] | to_roc }}
+
+{% endfor %}
+

--- a/exercises/practice/rectangles/.meta/tests.toml
+++ b/exercises/practice/rectangles/.meta/tests.toml
@@ -1,0 +1,52 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[485b7bab-4150-40aa-a8db-73013427d08c]
+description = "no rows"
+
+[076929ed-27e8-45dc-b14b-08279944dc49]
+description = "no columns"
+
+[0a8abbd1-a0a4-4180-aa4e-65c1b1a073fa]
+description = "no rectangles"
+
+[a4ba42e9-4e7f-4973-b7c7-4ce0760ac6cd]
+description = "one rectangle"
+
+[ced06550-83da-4d23-98b7-d24152e0db93]
+description = "two rectangles without shared parts"
+
+[5942d69a-a07c-41c8-8b93-2d13877c706a]
+description = "five rectangles with shared parts"
+
+[82d70be4-ab37-4bf2-a433-e33778d3bbf1]
+description = "rectangle of height 1 is counted"
+
+[57f1bc0e-2782-401e-ab12-7c01d8bfc2e0]
+description = "rectangle of width 1 is counted"
+
+[ef0bb65c-bd80-4561-9535-efc4067054f9]
+description = "1x1 square is counted"
+
+[e1e1d444-e926-4d30-9bf3-7d8ec9a9e330]
+description = "only complete rectangles are counted"
+
+[ca021a84-1281-4a56-9b9b-af14113933a4]
+description = "rectangles can be of different sizes"
+
+[51f689a7-ef3f-41ae-aa2f-5ea09ad897ff]
+description = "corner is required for a rectangle to be complete"
+
+[d78fe379-8c1b-4d3c-bdf7-29bfb6f6dc66]
+description = "large input with many rectangles"
+
+[6ef24e0f-d191-46da-b929-4faca24b4cd2]
+description = "rectangles must have four sides"

--- a/exercises/practice/rectangles/Rectangles.roc
+++ b/exercises/practice/rectangles/Rectangles.roc
@@ -1,0 +1,5 @@
+module [rectangles]
+
+rectangles : Str -> U64
+rectangles = \diagram ->
+    crash "Please implement the 'rectangles' function"

--- a/exercises/practice/rectangles/rectangles-test.roc
+++ b/exercises/practice/rectangles/rectangles-test.roc
@@ -1,0 +1,154 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/rectangles/canonical-data.json
+# File last updated on 2024-09-11
+app [main] {
+    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br",
+}
+
+main =
+    Task.ok {}
+
+import Rectangles exposing [rectangles]
+
+# no rows
+expect
+    result = rectangles ""
+    result == 0
+
+# no columns
+expect
+    result = rectangles ""
+    result == 0
+
+# no rectangles
+expect
+    result = rectangles " "
+    result == 0
+
+# one rectangle
+expect
+    result = rectangles
+        """
+        +-+
+        | |
+        +-+
+        """
+    result == 1
+
+# two rectangles without shared parts
+expect
+    result = rectangles
+        """
+          +-+
+          | |
+        +-+-+
+        | |  
+        +-+  
+        """
+    result == 2
+
+# five rectangles with shared parts
+expect
+    result = rectangles
+        """
+          +-+
+          | |
+        +-+-+
+        | | |
+        +-+-+
+        """
+    result == 5
+
+# rectangle of height 1 is counted
+expect
+    result = rectangles
+        """
+        +--+
+        +--+
+        """
+    result == 1
+
+# rectangle of width 1 is counted
+expect
+    result = rectangles
+        """
+        ++
+        ||
+        ++
+        """
+    result == 1
+
+# 1x1 square is counted
+expect
+    result = rectangles
+        """
+        ++
+        ++
+        """
+    result == 1
+
+# only complete rectangles are counted
+expect
+    result = rectangles
+        """
+          +-+
+            |
+        +-+-+
+        | | -
+        +-+-+
+        """
+    result == 1
+
+# rectangles can be of different sizes
+expect
+    result = rectangles
+        """
+        +------+----+
+        |      |    |
+        +---+--+    |
+        |   |       |
+        +---+-------+
+        """
+    result == 3
+
+# corner is required for a rectangle to be complete
+expect
+    result = rectangles
+        """
+        +------+----+
+        |      |    |
+        +------+    |
+        |   |       |
+        +---+-------+
+        """
+    result == 2
+
+# large input with many rectangles
+expect
+    result = rectangles
+        """
+        +---+--+----+
+        |   +--+----+
+        +---+--+    |
+        |   +--+----+
+        +---+--+--+-+
+        +---+--+--+-+
+        +------+  | |
+                  +-+
+        """
+    result == 60
+
+# rectangles must have four sides
+expect
+    result = rectangles
+        """
+        +-+ +-+
+        | | | |
+        +-+-+-+
+          | |  
+        +-+-+-+
+        | | | |
+        +-+ +-+
+        """
+    result == 5
+


### PR DESCRIPTION
There are many more efficient solutions (e.g., I could have located the corners first to drastically reduce the number of candidate top-left + bottom-right pairs, or I could have looked for connected pairs on each row first, etc.) but I got a bit lazy.