### PR TITLE
Ignore compiled programs and many other things

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,77 @@
-*.swp
-.DS_Store
-bin/configlet
+### Do not modify these first three ignore rules.  Needed to ignore files with no extension ###
+# Ignore all files including binary files that have no extension
+*
+# Unignore all files with extensions
+!*.*
+# Unignore all directories
+!*/
+
+# Specifically keep these files with no extension
+!Dockerfile
+!LICENSE*
+!LEGAL*
+!bin/add-exercise
+!bin/fetch-configlet
+!bin/install-roc
+!bin/verify-exercises
+
+# Ignore *.exe files except those in bin/
+*.exe
+!bin/*.exe
+
+# Ignore configlet
 bin/configlet.exe
+bin/configlet
+
+# Ignore problem specs directory
 .problem-specifications/
-**/__pycache__/
+
+# Ignore Python files
+*.beam
+*.pyc
+.ropeproject
+tmp
+.mypy_cache/
+.cache
+.pytest_cache
+__pycache__
+.venv
+
+# macOS .DS_Store files
+.DS_Store
+
+#editors
+.idea/
+.vscode/
+.ignore
+.exrc
+.vimrc
+.nvimrc
+
+# Other files to ignore
+.envrc
+*.a
+*.bak
+*.bc
+*.bk
+*.def
+*.dll
+*.dylib
+*.lib
+*.ll
+*.obj
+*.pdb
+*.so
+*.so.*
+*.swp
+*.tmp
+*.wasm
+
+# valgrind
+vgcore.*
+
+# roc cache files
+*.rh*
+*.rm*
+preprocessedhost
+metadata

--- a/.gitignore
+++ b/.gitignore
@@ -30,9 +30,7 @@ bin/configlet
 *.beam
 *.pyc
 .ropeproject
-tmp
 .mypy_cache/
-.cache
 .pytest_cache
 __pycache__
 .venv
@@ -48,7 +46,8 @@ __pycache__
 .vimrc
 .nvimrc
 
-# Other files to ignore
+# Other files and directories to ignore
+.cache
 .envrc
 *.a
 *.bak
@@ -66,6 +65,7 @@ __pycache__
 *.swp
 *.tmp
 *.wasm
+tmp
 
 # valgrind
 vgcore.*


### PR DESCRIPTION
This PR ignores way more things, including:
* compiled Roc files. If you run `roc run foo-test.roc` instead of `roc test foo-test.roc`, it will create `foo-test`, and there was a risk it might get commited by mistake: this PR removes this risk.
* several IDE configuration folders
* Various compilation results
* ...

Please read the full `.gitignore` for more details