### PR TITLE
Specialize Sublist type

### DIFF
--- a/exercises/practice/sublist/.meta/Example.roc
+++ b/exercises/practice/sublist/.meta/Example.roc
@@ -1,6 +1,6 @@
 module [sublist]
 
-sublist : List a, List a -> [Equal, Sublist, Superlist, Unequal] where a implements Eq
+sublist : List U8, List U8 -> [Equal, Sublist, Superlist, Unequal]
 sublist = \list1, list2 ->
     when List.len list1 |> Num.compare (List.len list2) is
         GT ->

--- a/exercises/practice/sublist/Sublist.roc
+++ b/exercises/practice/sublist/Sublist.roc
@@ -1,5 +1,5 @@
 module [sublist]
 
-sublist : List a, List a -> [Equal, Sublist, Superlist, Unequal] where a implements Eq
+sublist : List U8, List U8 -> [Equal, Sublist, Superlist, Unequal]
 sublist = \list1, list2 ->
     crash "Please implement the 'sublist' function"


### PR DESCRIPTION
I mentored a solution to this exercise where the user ended up with `sublist : List I32, List I32 -> [Equal, Sublist, Superlist, Unequal] where a implements Eq` as their type which I don't think should be allowed by the compiler. I think it would be best to keep types the types fully specialized by default so that they are very straightforward for the users and we don't have to introduce abilities unnecessarily.