### PR TITLE
Improve complex-numbers

### DIFF
--- a/exercises/practice/complex-numbers/.meta/Example.roc
+++ b/exercises/practice/complex-numbers/.meta/Example.roc
@@ -9,29 +9,29 @@ imaginary : Complex -> F64
 imaginary = \z -> z.im
 
 add : Complex, Complex -> Complex
-add = \z1, z2 -> {
-    re: z1.re + z2.re,
-    im: z1.im + z2.im,
+add = \{ re: a, im: b }, { re: c, im: d } -> {
+    re: a + c,
+    im: b + d,
 }
 
 sub : Complex, Complex -> Complex
-sub = \z1, z2 -> {
-    re: z1.re - z2.re,
-    im: z1.im - z2.im,
+sub = \{ re: a, im: b }, { re: c, im: d } -> {
+    re: a - c,
+    im: b - d,
 }
 
 mul : Complex, Complex -> Complex
-mul = \z1, z2 -> {
-    re: z1.re * z2.re - z1.im * z2.im,
-    im: z1.re * z2.im + z1.im * z2.re,
+mul = \{ re: a, im: b }, { re: c, im: d } -> {
+    re: a * c - b * d,
+    im: a * d + b * c,
 }
 
 div : Complex, Complex -> Complex
-div = \z1, z2 ->
-    denominator = z2.re * z2.re + z2.im * z2.im
+div = \{ re: a, im: b }, { re: c, im: d } ->
+    denominator = c * c + d * d
     {
-        re: (z1.re * z2.re + z1.im * z2.im) / denominator,
-        im: (z1.im * z2.re - z1.re * z2.im) / denominator,
+        re: (a * c + b * d) / denominator,
+        im: (b * c - a * d) / denominator,
     }
 
 conjugate : Complex -> Complex
@@ -41,8 +41,8 @@ conjugate = \z -> {
 }
 
 abs : Complex -> F64
-abs = \z ->
-    z.re * z.re + z.im * z.im |> Num.sqrt
+abs = \{ re: a, im: b } ->
+    a * a + b * b |> Num.sqrt
 
 exp : Complex -> Complex
 exp = \z ->

--- a/exercises/practice/complex-numbers/.meta/template.j2
+++ b/exercises/practice/complex-numbers/.meta/template.j2
@@ -32,7 +32,6 @@ expect
     {%- else %}
     result |> Num.isApproxEq {{ subcase["expected"] | to_roc }} {}
     {%- endif %}
-    
 {%- elif subcase["input"]["z1"] %}
 expect
     z1 = {{ plugins.to_complex_number(subcase["input"]["z1"]) }}
@@ -40,8 +39,6 @@ expect
     result = z1 |> {{ subcase["property"] }} z2
     expected = {{ plugins.to_complex_number(subcase["expected"]) }}
     result |> isApproxEq expected
-{%- else %}
-# This test case is not implemented: perhaps you can implement it?
 {%- endif %}
 
 {% endfor %}

--- a/exercises/practice/complex-numbers/complex-numbers-test.roc
+++ b/exercises/practice/complex-numbers/complex-numbers-test.roc
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/complex-numbers/canonical-data.json
-# File last updated on 2024-09-20
+# File last updated on 2024-09-21
 app [main] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br",
 }


### PR DESCRIPTION
Oops, I pushed #100 too fast.

This PR improves the complex-numbers exercise:
* removes the "not-implemented" section in `template.j2`
* uses destructuring in the solution to make the equations nicer to read