### PR TITLE
Add Alphametics exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -440,14 +440,6 @@
         "difficulty": 6
       },
       {
-        "slug": "alphametics",
-        "name": "Alphametics",
-        "uuid": "6bd98d4f-f95a-4fa2-981a-1684bd42334d",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 7
-      },
-      {
         "slug": "pig-latin",
         "name": "Pig Latin",
         "uuid": "8beb7c89-bf06-4eb1-b97f-36f2d9750dad",
@@ -462,6 +454,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7
+      },
+      {
+        "slug": "alphametics",
+        "name": "Alphametics",
+        "uuid": "6bd98d4f-f95a-4fa2-981a-1684bd42334d",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 8
       },
       {
         "slug": "grep",

--- a/config.json
+++ b/config.json
@@ -440,6 +440,14 @@
         "difficulty": 6
       },
       {
+        "slug": "alphametics",
+        "name": "Alphametics",
+        "uuid": "6bd98d4f-f95a-4fa2-981a-1684bd42334d",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 7
+      },
+      {
         "slug": "pig-latin",
         "name": "Pig Latin",
         "uuid": "8beb7c89-bf06-4eb1-b97f-36f2d9750dad",

--- a/exercises/practice/alphametics/.docs/instructions.md
+++ b/exercises/practice/alphametics/.docs/instructions.md
@@ -1,0 +1,29 @@
+# Instructions
+
+Given an alphametics puzzle, find the correct solution.
+
+[Alphametics][alphametics] is a puzzle where letters in words are replaced with numbers.
+
+For example `SEND + MORE = MONEY`:
+
+```text
+  S E N D
+  M O R E +
+-----------
+M O N E Y
+```
+
+Replacing these with valid numbers gives:
+
+```text
+  9 5 6 7
+  1 0 8 5 +
+-----------
+1 0 6 5 2
+```
+
+This is correct because every letter is replaced by a different number and the words, translated into numbers, then make a valid sum.
+
+Each letter must represent a different digit, and the leading digit of a multi-digit number must not be zero.
+
+[alphametics]: https://en.wikipedia.org/wiki/Alphametics

--- a/exercises/practice/alphametics/.meta/Example.roc
+++ b/exercises/practice/alphametics/.meta/Example.roc
@@ -12,8 +12,7 @@ solve = \problem ->
             insertTerm dict term 1
         |> insertTerm sum -1
 
-    # Leading digits can't be zero
-    cantBeZero =
+    leadingDigits =
         List.map addends \letters ->
             List.first letters |> Result.withDefault 0
         |> Set.fromList
@@ -35,14 +34,14 @@ solve = \problem ->
 
                 Ok assignments
 
-            [variable, .. as rest] ->
+            [letter, .. as rest] ->
                 findFirstOk remainingDigits \digit ->
-                    if digit == 0 && Set.contains cantBeZero variable then
+                    if digit == 0 && Set.contains leadingDigits letter then
                         Err InvalidAssignment
                         else
 
                     # Each digit has to be unique, so once we use a digit we remove it from the pool
-                    findMatch (List.append assignments (variable, digit)) rest (Set.remove remainingDigits digit)
+                    findMatch (List.append assignments (letter, digit)) rest (Set.remove remainingDigits digit)
 
     digits = List.range { start: At 0, end: At 9 } |> Set.fromList
     findMatch [] (Dict.keys equation) digits

--- a/exercises/practice/alphametics/.meta/Example.roc
+++ b/exercises/practice/alphametics/.meta/Example.roc
@@ -1,0 +1,5 @@
+module [solve]
+
+solve : Str -> Result (Set (U8, U64)) _
+solve = \problem ->
+    crash "Please implement 'solve'"

--- a/exercises/practice/alphametics/.meta/Example.roc
+++ b/exercises/practice/alphametics/.meta/Example.roc
@@ -3,31 +3,24 @@ module [solve]
 solve : Str -> Result (List (U8, U8)) _
 solve = \problem ->
     { addends, sum } = parse? problem
-    coefficients =
+
+    equation =
         List.walk addends (Dict.empty {}) \dict, term ->
             insertTerm dict term 1
         |> insertTerm sum -1
+
     cantBeZero =
         List.map addends \letters ->
             List.first letters |> Result.withDefault 0
         |> Set.fromList
         |> Set.insert (List.first sum |> Result.withDefault 0)
 
-    findMatch : List (U8, U8), List U8, Set U8 -> Result (List (U8, U8)) _
     findMatch = \assignments, remainingVars, remainingDigits ->
         when remainingVars is
             [] ->
-                invalidZero =
-                    List.any assignments \(letter, val) ->
-                        val == 0 && Set.contains cantBeZero letter
-
-                if invalidZero then
-                    Err InvalidAssignment
-                    else
-
                 totalVal =
                     List.walk assignments 0 \total, (letter, value) ->
-                        Dict.get coefficients letter
+                        Dict.get equation letter
                         |> Result.withDefault 0
                         |> Num.mul (Num.toI64 value)
                         |> Num.add total
@@ -39,23 +32,29 @@ solve = \problem ->
                 Ok assignments
 
             [variable, .. as rest] ->
-                keepFirstOk (Set.toList remainingDigits) \digit ->
+                findFirstOk (Set.toList remainingDigits) \digit ->
+                    if digit == 0 && Set.contains cantBeZero variable then
+                        Err InvalidAssignment
+                        else
+
                     findMatch (List.append assignments (variable, digit)) rest (Set.remove remainingDigits digit)
 
-    findMatch [] (Dict.keys coefficients) (List.range { start: At 0, end: At 9 } |> Set.fromList)
+    findMatch [] (Dict.keys equation) (List.range { start: At 0, end: At 9 } |> Set.fromList)
 
-keepFirstOk : List a, (a -> Result b err) -> Result b [NotFound]
-keepFirstOk = \list, func ->
+# Apply a function to each element of a list until the function returns an Ok, then return that value.
+findFirstOk : List a, (a -> Result b err) -> Result b [NotFound]
+findFirstOk = \list, func ->
     when list is
         [] -> Err NotFound
         [first, .. as rest] ->
             func first
-            |> Result.onErr \_ -> keepFirstOk rest func
+            |> Result.onErr \_ -> findFirstOk rest func
 
+# Update the equation with the values of a term
 insertTerm : Dict U8 I64, List U8, I64 -> Dict U8 I64
-insertTerm = \coefficients, letters, polarity ->
+insertTerm = \equation, letters, polarity ->
     List.reverse letters
-    |> List.walkWithIndex coefficients \dict, letter, index ->
+    |> List.walkWithIndex equation \dict, letter, index ->
         coeff =
             Num.powInt 10 index
             |> Num.toI64

--- a/exercises/practice/alphametics/.meta/Example.roc
+++ b/exercises/practice/alphametics/.meta/Example.roc
@@ -1,6 +1,6 @@
 module [solve]
 
-solve : Str -> Result (Set (U8, U8)) _
+solve : Str -> Result (List (U8, U8)) _
 solve = \problem ->
     { addends, sum } = parse? problem
     coefficients =
@@ -43,7 +43,6 @@ solve = \problem ->
                     findMatch (List.append assignments (variable, digit)) rest (Set.remove remainingDigits digit)
 
     findMatch [] (Dict.keys coefficients) (List.range { start: At 0, end: At 9 } |> Set.fromList)
-    |> Result.map Set.fromList
 
 keepFirstOk : List a, (a -> Result b err) -> Result b [NotFound]
 keepFirstOk = \list, func ->

--- a/exercises/practice/alphametics/.meta/Example.roc
+++ b/exercises/practice/alphametics/.meta/Example.roc
@@ -1,5 +1,75 @@
 module [solve]
 
-solve : Str -> Result (Set (U8, U64)) _
+solve : Str -> Result (Set (U8, U8)) _
 solve = \problem ->
-    crash "Please implement 'solve'"
+    { addends, sum } = parse? problem
+    coefficients =
+        List.walk addends (Dict.empty {}) \dict, term ->
+            insertTerm dict term 1
+        |> insertTerm sum -1
+    cantBeZero =
+        List.map addends \letters ->
+            List.first letters |> Result.withDefault 0
+        |> Set.fromList
+        |> Set.insert (List.first sum |> Result.withDefault 0)
+
+    findMatch : List (U8, U8), List U8, Set U8 -> Result (List (U8, U8)) _
+    findMatch = \assignments, remainingVars, remainingDigits ->
+        when remainingVars is
+            [] ->
+                invalidZero =
+                    List.any assignments \(letter, val) ->
+                        val == 0 && Set.contains cantBeZero letter
+
+                if invalidZero then
+                    Err InvalidAssignment
+                    else
+
+                totalVal =
+                    List.walk assignments 0 \total, (letter, value) ->
+                        Dict.get coefficients letter
+                        |> Result.withDefault 0
+                        |> Num.mul (Num.toI64 value)
+                        |> Num.add total
+
+                if totalVal != 0 then
+                    Err InvalidAssignment
+                    else
+
+                Ok assignments
+
+            [variable, .. as rest] ->
+                keepFirstOk (Set.toList remainingDigits) \digit ->
+                    findMatch (List.append assignments (variable, digit)) rest (Set.remove remainingDigits digit)
+
+    findMatch [] (Dict.keys coefficients) (List.range { start: At 0, end: At 9 } |> Set.fromList)
+    |> Result.map Set.fromList
+
+keepFirstOk : List a, (a -> Result b err) -> Result b [NotFound]
+keepFirstOk = \list, func ->
+    when list is
+        [] -> Err NotFound
+        [first, .. as rest] ->
+            func first
+            |> Result.onErr \_ -> keepFirstOk rest func
+
+insertTerm : Dict U8 I64, List U8, I64 -> Dict U8 I64
+insertTerm = \coefficients, letters, polarity ->
+    List.reverse letters
+    |> List.walkWithIndex coefficients \dict, letter, index ->
+        coeff =
+            Num.powInt 10 index
+            |> Num.toI64
+            |> Num.mul polarity
+        Dict.update dict letter \val ->
+            when val is
+                Missing -> Present coeff
+                Present c -> Present (c + coeff)
+
+parse : Str -> Result { addends : List (List U8), sum : List U8 } _
+parse = \problem ->
+    { before, after } = Str.splitFirst? problem " == "
+    addends =
+        Str.split before " + "
+        |> List.map Str.toUtf8
+    Ok { addends, sum: Str.toUtf8 after }

--- a/exercises/practice/alphametics/.meta/config.json
+++ b/exercises/practice/alphametics/.meta/config.json
@@ -1,0 +1,17 @@
+{
+  "authors": [
+    "isaacvando"
+  ],
+  "files": {
+    "solution": [
+      "Alphametics.roc"
+    ],
+    "test": [
+      "alphametics-test.roc"
+    ],
+    "example": [
+      ".meta/Example.roc"
+    ]
+  },
+  "blurb": "Given an alphametics puzzle, find the correct solution."
+}

--- a/exercises/practice/alphametics/.meta/template.j2
+++ b/exercises/practice/alphametics/.meta/template.j2
@@ -1,0 +1,20 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+{{ macros.header() }}
+
+import {{ exercise | to_pascal }} exposing [{{ cases[0]["property"] | to_camel }}]
+
+{% for case in cases -%}
+# {{ case["description"] }}
+expect
+    result = {{ case["property"] | to_camel }} {{ case["input"]["puzzle"] | to_roc }}
+    {%- if case["expected"] %}
+    result == Set.fromList [
+    {%- for letter, value in case["expected"].items() %}
+        ('{{ letter }}', {{ value }}),
+    {%- endfor %}
+        ]
+    {%- else %}
+    Result.isErr result
+    {%- endif %}
+{% endfor %}

--- a/exercises/practice/alphametics/.meta/template.j2
+++ b/exercises/practice/alphametics/.meta/template.j2
@@ -9,7 +9,7 @@ import {{ exercise | to_pascal }} exposing [{{ cases[0]["property"] | to_camel }
 expect
     result = {{ case["property"] | to_camel }} {{ case["input"]["puzzle"] | to_roc }}
     {%- if case["expected"] %}
-    Result.withDefault result (Set.empty {}) == Set.fromList [
+    Result.withDefault result [] |> Set.fromList == Set.fromList [
     {%- for letter, value in case["expected"].items() %}
         ('{{ letter }}', {{ value }}),
     {%- endfor %}

--- a/exercises/practice/alphametics/.meta/template.j2
+++ b/exercises/practice/alphametics/.meta/template.j2
@@ -9,7 +9,7 @@ import {{ exercise | to_pascal }} exposing [{{ cases[0]["property"] | to_camel }
 expect
     result = {{ case["property"] | to_camel }} {{ case["input"]["puzzle"] | to_roc }}
     {%- if case["expected"] %}
-    result == Set.fromList [
+    Result.withDefault result (Set.empty {}) == Set.fromList [
     {%- for letter, value in case["expected"].items() %}
         ('{{ letter }}', {{ value }}),
     {%- endfor %}
@@ -17,4 +17,5 @@ expect
     {%- else %}
     Result.isErr result
     {%- endif %}
+
 {% endfor %}

--- a/exercises/practice/alphametics/.meta/tests.toml
+++ b/exercises/practice/alphametics/.meta/tests.toml
@@ -1,0 +1,40 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[e0c08b07-9028-4d5f-91e1-d178fead8e1a]
+description = "puzzle with three letters"
+
+[a504ee41-cb92-4ec2-9f11-c37e95ab3f25]
+description = "solution must have unique value for each letter"
+
+[4e3b81d2-be7b-4c5c-9a80-cd72bc6d465a]
+description = "leading zero solution is invalid"
+
+[8a3e3168-d1ee-4df7-94c7-b9c54845ac3a]
+description = "puzzle with two digits final carry"
+
+[a9630645-15bd-48b6-a61e-d85c4021cc09]
+description = "puzzle with four letters"
+
+[3d905a86-5a52-4e4e-bf80-8951535791bd]
+description = "puzzle with six letters"
+
+[4febca56-e7b7-4789-97b9-530d09ba95f0]
+description = "puzzle with seven letters"
+
+[12125a75-7284-4f9a-a5fa-191471e0d44f]
+description = "puzzle with eight letters"
+
+[fb05955f-38dc-477a-a0b6-5ef78969fffa]
+description = "puzzle with ten letters"
+
+[9a101e81-9216-472b-b458-b513a7adacf7]
+description = "puzzle with ten letters and 199 addends"

--- a/exercises/practice/alphametics/Alphametics.roc
+++ b/exercises/practice/alphametics/Alphametics.roc
@@ -1,5 +1,5 @@
 module [solve]
 
-solve : Str -> Result (Set (U8, U64)) _
+solve : Str -> Result (List (U8, U64)) _
 solve = \problem ->
     crash "Please implement 'solve'"

--- a/exercises/practice/alphametics/Alphametics.roc
+++ b/exercises/practice/alphametics/Alphametics.roc
@@ -1,0 +1,5 @@
+module [solve]
+
+solve : Str -> Result (Set (U8, U64)) _
+solve = \problem ->
+    crash "Please implement 'solve'"

--- a/exercises/practice/alphametics/Alphametics.roc
+++ b/exercises/practice/alphametics/Alphametics.roc
@@ -1,5 +1,5 @@
 module [solve]
 
-solve : Str -> Result (List (U8, U64)) _
+solve : Str -> Result (List (U8, U8)) _
 solve = \problem ->
     crash "Please implement 'solve'"

--- a/exercises/practice/alphametics/alphametics-test.roc
+++ b/exercises/practice/alphametics/alphametics-test.roc
@@ -1,0 +1,120 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/alphametics/canonical-data.json
+# File last updated on 2024-09-21
+app [main] {
+    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br",
+}
+
+main =
+    Task.ok {}
+
+import Alphametics exposing [solve]
+
+# puzzle with three letters
+expect
+    result = solve "I + BB == ILL"
+    result
+    == Set.fromList [
+        ('I', 1),
+        ('B', 9),
+        ('L', 0),
+    ]
+# solution must have unique value for each letter
+expect
+    result = solve "A == B"
+    Result.isErr result
+# leading zero solution is invalid
+expect
+    result = solve "ACA + DD == BD"
+    Result.isErr result
+# puzzle with two digits final carry
+expect
+    result = solve "A + A + A + A + A + A + A + A + A + A + A + B == BCC"
+    result
+    == Set.fromList [
+        ('A', 9),
+        ('B', 1),
+        ('C', 0),
+    ]
+# puzzle with four letters
+expect
+    result = solve "AS + A == MOM"
+    result
+    == Set.fromList [
+        ('A', 9),
+        ('S', 2),
+        ('M', 1),
+        ('O', 0),
+    ]
+# puzzle with six letters
+expect
+    result = solve "NO + NO + TOO == LATE"
+    result
+    == Set.fromList [
+        ('N', 7),
+        ('O', 4),
+        ('T', 9),
+        ('L', 1),
+        ('A', 0),
+        ('E', 2),
+    ]
+# puzzle with seven letters
+expect
+    result = solve "HE + SEES + THE == LIGHT"
+    result
+    == Set.fromList [
+        ('E', 4),
+        ('G', 2),
+        ('H', 5),
+        ('I', 0),
+        ('L', 1),
+        ('S', 9),
+        ('T', 7),
+    ]
+# puzzle with eight letters
+expect
+    result = solve "SEND + MORE == MONEY"
+    result
+    == Set.fromList [
+        ('S', 9),
+        ('E', 5),
+        ('N', 6),
+        ('D', 7),
+        ('M', 1),
+        ('O', 0),
+        ('R', 8),
+        ('Y', 2),
+    ]
+# puzzle with ten letters
+expect
+    result = solve "AND + A + STRONG + OFFENSE + AS + A + GOOD == DEFENSE"
+    result
+    == Set.fromList [
+        ('A', 5),
+        ('D', 3),
+        ('E', 4),
+        ('F', 7),
+        ('G', 8),
+        ('N', 0),
+        ('O', 2),
+        ('R', 1),
+        ('S', 6),
+        ('T', 9),
+    ]
+# puzzle with ten letters and 199 addends
+expect
+    result = solve "THIS + A + FIRE + THEREFORE + FOR + ALL + HISTORIES + I + TELL + A + TALE + THAT + FALSIFIES + ITS + TITLE + TIS + A + LIE + THE + TALE + OF + THE + LAST + FIRE + HORSES + LATE + AFTER + THE + FIRST + FATHERS + FORESEE + THE + HORRORS + THE + LAST + FREE + TROLL + TERRIFIES + THE + HORSES + OF + FIRE + THE + TROLL + RESTS + AT + THE + HOLE + OF + LOSSES + IT + IS + THERE + THAT + SHE + STORES + ROLES + OF + LEATHERS + AFTER + SHE + SATISFIES + HER + HATE + OFF + THOSE + FEARS + A + TASTE + RISES + AS + SHE + HEARS + THE + LEAST + FAR + HORSE + THOSE + FAST + HORSES + THAT + FIRST + HEAR + THE + TROLL + FLEE + OFF + TO + THE + FOREST + THE + HORSES + THAT + ALERTS + RAISE + THE + STARES + OF + THE + OTHERS + AS + THE + TROLL + ASSAILS + AT + THE + TOTAL + SHIFT + HER + TEETH + TEAR + HOOF + OFF + TORSO + AS + THE + LAST + HORSE + FORFEITS + ITS + LIFE + THE + FIRST + FATHERS + HEAR + OF + THE + HORRORS + THEIR + FEARS + THAT + THE + FIRES + FOR + THEIR + FEASTS + ARREST + AS + THE + FIRST + FATHERS + RESETTLE + THE + LAST + OF + THE + FIRE + HORSES + THE + LAST + TROLL + HARASSES + THE + FOREST + HEART + FREE + AT + LAST + OF + THE + LAST + TROLL + ALL + OFFER + THEIR + FIRE + HEAT + TO + THE + ASSISTERS + FAR + OFF + THE + TROLL + FASTS + ITS + LIFE + SHORTER + AS + STARS + RISE + THE + HORSES + REST + SAFE + AFTER + ALL + SHARE + HOT + FISH + AS + THEIR + AFFILIATES + TAILOR + A + ROOFS + FOR + THEIR + SAFE == FORTRESSES"
+    result
+    == Set.fromList [
+        ('A', 1),
+        ('E', 0),
+        ('F', 5),
+        ('H', 8),
+        ('I', 7),
+        ('L', 2),
+        ('O', 6),
+        ('R', 3),
+        ('S', 4),
+        ('T', 9),
+    ]
+

--- a/exercises/practice/alphametics/alphametics-test.roc
+++ b/exercises/practice/alphametics/alphametics-test.roc
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/alphametics/canonical-data.json
-# File last updated on 2024-09-21
+# File last updated on 2024-09-22
 app [main] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br",
 }
@@ -13,43 +13,48 @@ import Alphametics exposing [solve]
 # puzzle with three letters
 expect
     result = solve "I + BB == ILL"
-    result
+    Result.withDefault result (Set.empty {})
     == Set.fromList [
         ('I', 1),
         ('B', 9),
         ('L', 0),
     ]
+
 # solution must have unique value for each letter
 expect
     result = solve "A == B"
     Result.isErr result
+
 # leading zero solution is invalid
 expect
     result = solve "ACA + DD == BD"
     Result.isErr result
+
 # puzzle with two digits final carry
 expect
     result = solve "A + A + A + A + A + A + A + A + A + A + A + B == BCC"
-    result
+    Result.withDefault result (Set.empty {})
     == Set.fromList [
         ('A', 9),
         ('B', 1),
         ('C', 0),
     ]
+
 # puzzle with four letters
 expect
     result = solve "AS + A == MOM"
-    result
+    Result.withDefault result (Set.empty {})
     == Set.fromList [
         ('A', 9),
         ('S', 2),
         ('M', 1),
         ('O', 0),
     ]
+
 # puzzle with six letters
 expect
     result = solve "NO + NO + TOO == LATE"
-    result
+    Result.withDefault result (Set.empty {})
     == Set.fromList [
         ('N', 7),
         ('O', 4),
@@ -58,10 +63,11 @@ expect
         ('A', 0),
         ('E', 2),
     ]
+
 # puzzle with seven letters
 expect
     result = solve "HE + SEES + THE == LIGHT"
-    result
+    Result.withDefault result (Set.empty {})
     == Set.fromList [
         ('E', 4),
         ('G', 2),
@@ -71,10 +77,11 @@ expect
         ('S', 9),
         ('T', 7),
     ]
+
 # puzzle with eight letters
 expect
     result = solve "SEND + MORE == MONEY"
-    result
+    Result.withDefault result (Set.empty {})
     == Set.fromList [
         ('S', 9),
         ('E', 5),
@@ -85,10 +92,11 @@ expect
         ('R', 8),
         ('Y', 2),
     ]
+
 # puzzle with ten letters
 expect
     result = solve "AND + A + STRONG + OFFENSE + AS + A + GOOD == DEFENSE"
-    result
+    Result.withDefault result (Set.empty {})
     == Set.fromList [
         ('A', 5),
         ('D', 3),
@@ -101,10 +109,11 @@ expect
         ('S', 6),
         ('T', 9),
     ]
+
 # puzzle with ten letters and 199 addends
 expect
     result = solve "THIS + A + FIRE + THEREFORE + FOR + ALL + HISTORIES + I + TELL + A + TALE + THAT + FALSIFIES + ITS + TITLE + TIS + A + LIE + THE + TALE + OF + THE + LAST + FIRE + HORSES + LATE + AFTER + THE + FIRST + FATHERS + FORESEE + THE + HORRORS + THE + LAST + FREE + TROLL + TERRIFIES + THE + HORSES + OF + FIRE + THE + TROLL + RESTS + AT + THE + HOLE + OF + LOSSES + IT + IS + THERE + THAT + SHE + STORES + ROLES + OF + LEATHERS + AFTER + SHE + SATISFIES + HER + HATE + OFF + THOSE + FEARS + A + TASTE + RISES + AS + SHE + HEARS + THE + LEAST + FAR + HORSE + THOSE + FAST + HORSES + THAT + FIRST + HEAR + THE + TROLL + FLEE + OFF + TO + THE + FOREST + THE + HORSES + THAT + ALERTS + RAISE + THE + STARES + OF + THE + OTHERS + AS + THE + TROLL + ASSAILS + AT + THE + TOTAL + SHIFT + HER + TEETH + TEAR + HOOF + OFF + TORSO + AS + THE + LAST + HORSE + FORFEITS + ITS + LIFE + THE + FIRST + FATHERS + HEAR + OF + THE + HORRORS + THEIR + FEARS + THAT + THE + FIRES + FOR + THEIR + FEASTS + ARREST + AS + THE + FIRST + FATHERS + RESETTLE + THE + LAST + OF + THE + FIRE + HORSES + THE + LAST + TROLL + HARASSES + THE + FOREST + HEART + FREE + AT + LAST + OF + THE + LAST + TROLL + ALL + OFFER + THEIR + FIRE + HEAT + TO + THE + ASSISTERS + FAR + OFF + THE + TROLL + FASTS + ITS + LIFE + SHORTER + AS + STARS + RISE + THE + HORSES + REST + SAFE + AFTER + ALL + SHARE + HOT + FISH + AS + THEIR + AFFILIATES + TAILOR + A + ROOFS + FOR + THEIR + SAFE == FORTRESSES"
-    result
+    Result.withDefault result (Set.empty {})
     == Set.fromList [
         ('A', 1),
         ('E', 0),

--- a/exercises/practice/alphametics/alphametics-test.roc
+++ b/exercises/practice/alphametics/alphametics-test.roc
@@ -13,7 +13,8 @@ import Alphametics exposing [solve]
 # puzzle with three letters
 expect
     result = solve "I + BB == ILL"
-    Result.withDefault result (Set.empty {})
+    Result.withDefault result []
+    |> Set.fromList
     == Set.fromList [
         ('I', 1),
         ('B', 9),
@@ -33,7 +34,8 @@ expect
 # puzzle with two digits final carry
 expect
     result = solve "A + A + A + A + A + A + A + A + A + A + A + B == BCC"
-    Result.withDefault result (Set.empty {})
+    Result.withDefault result []
+    |> Set.fromList
     == Set.fromList [
         ('A', 9),
         ('B', 1),
@@ -43,7 +45,8 @@ expect
 # puzzle with four letters
 expect
     result = solve "AS + A == MOM"
-    Result.withDefault result (Set.empty {})
+    Result.withDefault result []
+    |> Set.fromList
     == Set.fromList [
         ('A', 9),
         ('S', 2),
@@ -54,7 +57,8 @@ expect
 # puzzle with six letters
 expect
     result = solve "NO + NO + TOO == LATE"
-    Result.withDefault result (Set.empty {})
+    Result.withDefault result []
+    |> Set.fromList
     == Set.fromList [
         ('N', 7),
         ('O', 4),
@@ -67,7 +71,8 @@ expect
 # puzzle with seven letters
 expect
     result = solve "HE + SEES + THE == LIGHT"
-    Result.withDefault result (Set.empty {})
+    Result.withDefault result []
+    |> Set.fromList
     == Set.fromList [
         ('E', 4),
         ('G', 2),
@@ -81,7 +86,8 @@ expect
 # puzzle with eight letters
 expect
     result = solve "SEND + MORE == MONEY"
-    Result.withDefault result (Set.empty {})
+    Result.withDefault result []
+    |> Set.fromList
     == Set.fromList [
         ('S', 9),
         ('E', 5),
@@ -96,7 +102,8 @@ expect
 # puzzle with ten letters
 expect
     result = solve "AND + A + STRONG + OFFENSE + AS + A + GOOD == DEFENSE"
-    Result.withDefault result (Set.empty {})
+    Result.withDefault result []
+    |> Set.fromList
     == Set.fromList [
         ('A', 5),
         ('D', 3),
@@ -113,7 +120,8 @@ expect
 # puzzle with ten letters and 199 addends
 expect
     result = solve "THIS + A + FIRE + THEREFORE + FOR + ALL + HISTORIES + I + TELL + A + TALE + THAT + FALSIFIES + ITS + TITLE + TIS + A + LIE + THE + TALE + OF + THE + LAST + FIRE + HORSES + LATE + AFTER + THE + FIRST + FATHERS + FORESEE + THE + HORRORS + THE + LAST + FREE + TROLL + TERRIFIES + THE + HORSES + OF + FIRE + THE + TROLL + RESTS + AT + THE + HOLE + OF + LOSSES + IT + IS + THERE + THAT + SHE + STORES + ROLES + OF + LEATHERS + AFTER + SHE + SATISFIES + HER + HATE + OFF + THOSE + FEARS + A + TASTE + RISES + AS + SHE + HEARS + THE + LEAST + FAR + HORSE + THOSE + FAST + HORSES + THAT + FIRST + HEAR + THE + TROLL + FLEE + OFF + TO + THE + FOREST + THE + HORSES + THAT + ALERTS + RAISE + THE + STARES + OF + THE + OTHERS + AS + THE + TROLL + ASSAILS + AT + THE + TOTAL + SHIFT + HER + TEETH + TEAR + HOOF + OFF + TORSO + AS + THE + LAST + HORSE + FORFEITS + ITS + LIFE + THE + FIRST + FATHERS + HEAR + OF + THE + HORRORS + THEIR + FEARS + THAT + THE + FIRES + FOR + THEIR + FEASTS + ARREST + AS + THE + FIRST + FATHERS + RESETTLE + THE + LAST + OF + THE + FIRE + HORSES + THE + LAST + TROLL + HARASSES + THE + FOREST + HEART + FREE + AT + LAST + OF + THE + LAST + TROLL + ALL + OFFER + THEIR + FIRE + HEAT + TO + THE + ASSISTERS + FAR + OFF + THE + TROLL + FASTS + ITS + LIFE + SHORTER + AS + STARS + RISE + THE + HORSES + REST + SAFE + AFTER + ALL + SHARE + HOT + FISH + AS + THEIR + AFFILIATES + TAILOR + A + ROOFS + FOR + THEIR + SAFE == FORTRESSES"
-    Result.withDefault result (Set.empty {})
+    Result.withDefault result []
+    |> Set.fromList
     == Set.fromList [
         ('A', 1),
         ('E', 0),


### PR DESCRIPTION
Originally I had `solve` return a set, but I decided to change it to a list instead because right now the inspect output for sets is very noisy so it makes it difficult to use the test failure output.