### PR TITLE
Add two bucket

### DIFF
--- a/config.json
+++ b/config.json
@@ -568,6 +568,14 @@
         "difficulty": 6
       },
       {
+        "slug": "two-bucket",
+        "name": "Two Bucket",
+        "uuid": "4d743bc2-1d84-49f8-babe-894e59006264",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 6
+      },
+      {
         "slug": "bowling",
         "name": "Bowling",
         "uuid": "308493bb-182f-4a48-bafb-56c5b2f214e5",

--- a/exercises/practice/two-bucket/.docs/instructions.md
+++ b/exercises/practice/two-bucket/.docs/instructions.md
@@ -1,0 +1,46 @@
+# Instructions
+
+Given two buckets of different size and which bucket to fill first, determine how many actions are required to measure an exact number of liters by strategically transferring fluid between the buckets.
+
+There are some rules that your solution must follow:
+
+- You can only do one action at a time.
+- There are only 3 possible actions:
+  1. Pouring one bucket into the other bucket until either:
+     a) the first bucket is empty
+     b) the second bucket is full
+  2. Emptying a bucket and doing nothing to the other.
+  3. Filling a bucket and doing nothing to the other.
+- After an action, you may not arrive at a state where the initial starting bucket is empty and the other bucket is full.
+
+Your program will take as input:
+
+- the size of bucket one
+- the size of bucket two
+- the desired number of liters to reach
+- which bucket to fill first, either bucket one or bucket two
+
+Your program should determine:
+
+- the total number of actions it should take to reach the desired number of liters, including the first fill of the starting bucket
+- which bucket should end up with the desired number of liters - either bucket one or bucket two
+- how many liters are left in the other bucket
+
+Note: any time a change is made to either or both buckets counts as one (1) action.
+
+Example:
+Bucket one can hold up to 7 liters, and bucket two can hold up to 11 liters.
+Let's say at a given step, bucket one is holding 7 liters and bucket two is holding 8 liters (7,8).
+If you empty bucket one and make no change to bucket two, leaving you with 0 liters and 8 liters respectively (0,8), that counts as one action.
+Instead, if you had poured from bucket one into bucket two until bucket two was full, resulting in 4 liters in bucket one and 11 liters in bucket two (4,11), that would also only count as one action.
+
+Another Example:
+Bucket one can hold 3 liters, and bucket two can hold up to 5 liters.
+You are told you must start with bucket one.
+So your first action is to fill bucket one.
+You choose to empty bucket one for your second action.
+For your third action, you may not fill bucket two, because this violates the third rule -- you may not end up in a state after any action where the starting bucket is empty and the other bucket is full.
+
+Written with <3 at [Fullstack Academy][fullstack] by Lindsay Levine.
+
+[fullstack]: https://www.fullstackacademy.com/

--- a/exercises/practice/two-bucket/.meta/Example.roc
+++ b/exercises/practice/two-bucket/.meta/Example.roc
@@ -1,0 +1,8 @@
+module [measure]
+
+measure :
+    { bucketOne : U64, bucketTwo : U64, goal : U64, startBucket : [One, Two] }
+    ->
+    { moves : U64, goalBucket : [One, Two], otherBucket : U64 }
+measure = \{ bucketOne, bucketTwo, goal, startBucket } ->
+    crash "Please implement the 'measure' function"

--- a/exercises/practice/two-bucket/.meta/Example.roc
+++ b/exercises/practice/two-bucket/.meta/Example.roc
@@ -22,15 +22,15 @@ bfs = \{ start, neighbors, success } ->
                     pathBackToStart [] node |> List.reverse |> Ok
                     else
 
-                neighorNodes = neighbors node
+                neighborNodes = neighbors node
                 newFrom =
-                    neighorNodes
+                    neighborNodes
                     |> List.dropIf \neighbor -> visited |> Set.contains neighbor
                     |> List.map \neighbor -> (neighbor, node)
                     |> Dict.fromList
                 updatedFrom = from |> Dict.insertAll newFrom
                 updatedVisited = visited |> Set.insert node
-                updatedToVisit = restToVisit |> List.concat neighorNodes
+                updatedToVisit = restToVisit |> List.concat neighborNodes
                 help updatedToVisit updatedVisited updatedFrom
     help [start] (Set.empty {}) (Dict.empty {})
 

--- a/exercises/practice/two-bucket/.meta/Example.roc
+++ b/exercises/practice/two-bucket/.meta/Example.roc
@@ -1,8 +1,89 @@
 module [measure]
 
+## Breadth-First Search finds the shortest path from the `start` node to any successful
+## node (i.e., such that `success node == Bool.true`). The `neighbors` function must
+## return the list of direct neighbors of a given node.
+bfs : { start : a, neighbors : a -> List a, success : a -> Bool }
+    ->
+    Result (List a) [NoPathExists] where a implements Hash & Eq
+bfs = \{ start, neighbors, success } ->
+    help = \toVisit, visited, from ->
+        when toVisit is
+            [] -> Err NoPathExists
+            [node, .. as restToVisit] ->
+                if visited |> Set.contains node then
+                    help restToVisit visited from
+                else if success node then
+                    pathBackToStart = \path, step ->
+                        updatedPath = path |> List.append step
+                        when from |> Dict.get step is
+                            Ok previous -> pathBackToStart updatedPath previous
+                            Err KeyNotFound -> updatedPath
+                    pathBackToStart [] node |> List.reverse |> Ok
+                    else
+
+                neighorNodes = neighbors node
+                newFrom =
+                    neighorNodes
+                    |> List.dropIf \neighbor -> visited |> Set.contains neighbor
+                    |> List.map \neighbor -> (neighbor, node)
+                    |> Dict.fromList
+                updatedFrom = from |> Dict.insertAll newFrom
+                updatedVisited = visited |> Set.insert node
+                updatedToVisit = restToVisit |> List.concat neighorNodes
+                help updatedToVisit updatedVisited updatedFrom
+    help [start] (Set.empty {}) (Dict.empty {})
+
 measure :
     { bucketOne : U64, bucketTwo : U64, goal : U64, startBucket : [One, Two] }
     ->
-    { moves : U64, goalBucket : [One, Two], otherBucket : U64 }
+    Result { moves : U64, goalBucket : [One, Two], otherBucket : U64 } [NoSolutionExists]
 measure = \{ bucketOne, bucketTwo, goal, startBucket } ->
-    crash "Please implement the 'measure' function"
+    if goal == 0 then
+        Ok { moves: 0, goalBucket: One, otherBucket: 0 }
+        else
+
+    start =
+        when startBucket is
+            One -> { volumeOne: bucketOne, volumeTwo: 0 }
+            Two -> { volumeOne: 0, volumeTwo: bucketTwo }
+
+    neighbors = \{ volumeOne, volumeTwo } ->
+        volumeOneToTwo = Num.min volumeOne (bucketTwo - volumeTwo)
+        volumeTwoToOne = Num.min volumeTwo (bucketOne - volumeOne)
+        [
+            { volumeOne: 0, volumeTwo }, # empty bucket one
+            { volumeOne, volumeTwo: 0 }, # empty bucket two
+            { volumeOne: bucketOne, volumeTwo }, # fill bucket one
+            { volumeOne, volumeTwo: bucketTwo }, # fill bucket two
+            {
+                # pour bucket one into bucket two
+                volumeOne: volumeOne - volumeOneToTwo,
+                volumeTwo: volumeTwo + volumeOneToTwo,
+            },
+            {
+                # pour bucket two into bucket one
+                volumeOne: volumeOne + volumeTwoToOne,
+                volumeTwo: volumeTwo - volumeTwoToOne,
+            },
+        ]
+        |> List.dropIf \{ volumeOne: v1, volumeTwo: v2 } ->
+            (v1 == volumeOne && v2 == volumeTwo) # no change
+            ||
+            # forbidden move: cannot end up with the starting bucket empty and
+            # the other bucket full
+            when startBucket is
+                One -> v1 == 0 && v2 == bucketTwo
+                Two -> v1 == bucketOne && v2 == 0
+
+    success = \{ volumeOne, volumeTwo } -> volumeOne == goal || volumeTwo == goal
+
+    when bfs { start, neighbors, success } is
+        Ok [.. as rest, last] ->
+            Ok {
+                moves: List.len rest + 1,
+                goalBucket: if last.volumeOne == goal then One else Two,
+                otherBucket: if last.volumeOne == goal then last.volumeTwo else last.volumeOne,
+            }
+
+        _ -> Err NoSolutionExists

--- a/exercises/practice/two-bucket/.meta/config.json
+++ b/exercises/practice/two-bucket/.meta/config.json
@@ -1,0 +1,19 @@
+{
+  "authors": [
+    "ageron"
+  ],
+  "files": {
+    "solution": [
+      "TwoBucket.roc"
+    ],
+    "test": [
+      "two-bucket-test.roc"
+    ],
+    "example": [
+      ".meta/Example.roc"
+    ]
+  },
+  "blurb": "Given two buckets of different size, demonstrate how to measure an exact number of liters.",
+  "source": "Water Pouring Problem",
+  "source_url": "https://demonstrations.wolfram.com/WaterPouringProblem/"
+}

--- a/exercises/practice/two-bucket/.meta/template.j2
+++ b/exercises/practice/two-bucket/.meta/template.j2
@@ -1,0 +1,27 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+{{ macros.header() }}
+
+import {{ exercise | to_pascal }} exposing [{{ cases[0]["property"] | to_camel }}]
+
+{% for case in cases -%}
+# {{ case["description"] }}
+expect
+    result = {{ case["property"] | to_camel }} {
+        bucketOne: {{ case["input"]["bucketOne"] }},
+        bucketTwo: {{ case["input"]["bucketTwo"] }},
+        goal: {{ case["input"]["goal"] }},
+        startBucket: {{ case["input"]["startBucket"] | to_pascal }},
+    }
+    {%- if case["expected"]["error"] %}
+    result |> Result.isErr
+    {%- else %}
+    expected = {
+        moves: {{ case["expected"]["moves"] }},
+        goalBucket: {{ case["expected"]["goalBucket"] | to_pascal }},
+        otherBucket: {{ case["expected"]["otherBucket"] }},
+    }
+    result == expected
+    {%- endif %}
+
+{% endfor %}

--- a/exercises/practice/two-bucket/.meta/template.j2
+++ b/exercises/practice/two-bucket/.meta/template.j2
@@ -16,7 +16,7 @@ expect
     {%- if case["expected"]["error"] %}
     result |> Result.isErr
     {%- else %}
-    expected = {
+    expected = Ok {
         moves: {{ case["expected"]["moves"] }},
         goalBucket: {{ case["expected"]["goalBucket"] | to_pascal }},
         otherBucket: {{ case["expected"]["otherBucket"] }},

--- a/exercises/practice/two-bucket/.meta/tests.toml
+++ b/exercises/practice/two-bucket/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[a6f2b4ba-065f-4dca-b6f0-e3eee51cb661]
+description = "Measure using bucket one of size 3 and bucket two of size 5 - start with bucket one"
+
+[6c4ea451-9678-4926-b9b3-68364e066d40]
+description = "Measure using bucket one of size 3 and bucket two of size 5 - start with bucket two"
+
+[3389f45e-6a56-46d5-9607-75aa930502ff]
+description = "Measure using bucket one of size 7 and bucket two of size 11 - start with bucket one"
+
+[fe0ff9a0-3ea5-4bf7-b17d-6d4243961aa1]
+description = "Measure using bucket one of size 7 and bucket two of size 11 - start with bucket two"
+
+[0ee1f57e-da84-44f7-ac91-38b878691602]
+description = "Measure one step using bucket one of size 1 and bucket two of size 3 - start with bucket two"
+
+[eb329c63-5540-4735-b30b-97f7f4df0f84]
+description = "Measure using bucket one of size 2 and bucket two of size 3 - start with bucket one and end with bucket two"
+
+[449be72d-b10a-4f4b-a959-ca741e333b72]
+description = "Not possible to reach the goal"
+
+[aac38b7a-77f4-4d62-9b91-8846d533b054]
+description = "With the same buckets but a different goal, then it is possible"
+
+[74633132-0ccf-49de-8450-af4ab2e3b299]
+description = "Goal larger than both buckets is impossible"

--- a/exercises/practice/two-bucket/TwoBucket.roc
+++ b/exercises/practice/two-bucket/TwoBucket.roc
@@ -1,0 +1,8 @@
+module [measure]
+
+measure :
+    { bucketOne : U64, bucketTwo : U64, goal : U64, startBucket : [One, Two] }
+    ->
+    { moves : U64, goalBucket : [One, Two], otherBucket : U64 }
+measure = \{ bucketOne, bucketTwo, goal, startBucket } ->
+    crash "Please implement the 'measure' function"

--- a/exercises/practice/two-bucket/TwoBucket.roc
+++ b/exercises/practice/two-bucket/TwoBucket.roc
@@ -3,6 +3,6 @@ module [measure]
 measure :
     { bucketOne : U64, bucketTwo : U64, goal : U64, startBucket : [One, Two] }
     ->
-    { moves : U64, goalBucket : [One, Two], otherBucket : U64 }
+    Result { moves : U64, goalBucket : [One, Two], otherBucket : U64 } _
 measure = \{ bucketOne, bucketTwo, goal, startBucket } ->
     crash "Please implement the 'measure' function"

--- a/exercises/practice/two-bucket/two-bucket-test.roc
+++ b/exercises/practice/two-bucket/two-bucket-test.roc
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/two-bucket/canonical-data.json
-# File last updated on 2024-09-30
+# File last updated on 2024-10-01
 app [main] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br",
 }
@@ -18,7 +18,7 @@ expect
         goal: 1,
         startBucket: One,
     }
-    expected = {
+    expected = Ok {
         moves: 4,
         goalBucket: One,
         otherBucket: 5,
@@ -33,7 +33,7 @@ expect
         goal: 1,
         startBucket: Two,
     }
-    expected = {
+    expected = Ok {
         moves: 8,
         goalBucket: Two,
         otherBucket: 3,
@@ -48,7 +48,7 @@ expect
         goal: 2,
         startBucket: One,
     }
-    expected = {
+    expected = Ok {
         moves: 14,
         goalBucket: One,
         otherBucket: 11,
@@ -63,7 +63,7 @@ expect
         goal: 2,
         startBucket: Two,
     }
-    expected = {
+    expected = Ok {
         moves: 18,
         goalBucket: Two,
         otherBucket: 7,
@@ -78,7 +78,7 @@ expect
         goal: 3,
         startBucket: Two,
     }
-    expected = {
+    expected = Ok {
         moves: 1,
         goalBucket: Two,
         otherBucket: 0,
@@ -93,7 +93,7 @@ expect
         goal: 3,
         startBucket: One,
     }
-    expected = {
+    expected = Ok {
         moves: 2,
         goalBucket: Two,
         otherBucket: 2,
@@ -118,7 +118,7 @@ expect
         goal: 9,
         startBucket: One,
     }
-    expected = {
+    expected = Ok {
         moves: 10,
         goalBucket: Two,
         otherBucket: 0,

--- a/exercises/practice/two-bucket/two-bucket-test.roc
+++ b/exercises/practice/two-bucket/two-bucket-test.roc
@@ -1,0 +1,137 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/two-bucket/canonical-data.json
+# File last updated on 2024-09-30
+app [main] {
+    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br",
+}
+
+main =
+    Task.ok {}
+
+import TwoBucket exposing [measure]
+
+# Measure using bucket one of size 3 and bucket two of size 5 - start with bucket one
+expect
+    result = measure {
+        bucketOne: 3,
+        bucketTwo: 5,
+        goal: 1,
+        startBucket: One,
+    }
+    expected = {
+        moves: 4,
+        goalBucket: One,
+        otherBucket: 5,
+    }
+    result == expected
+
+# Measure using bucket one of size 3 and bucket two of size 5 - start with bucket two
+expect
+    result = measure {
+        bucketOne: 3,
+        bucketTwo: 5,
+        goal: 1,
+        startBucket: Two,
+    }
+    expected = {
+        moves: 8,
+        goalBucket: Two,
+        otherBucket: 3,
+    }
+    result == expected
+
+# Measure using bucket one of size 7 and bucket two of size 11 - start with bucket one
+expect
+    result = measure {
+        bucketOne: 7,
+        bucketTwo: 11,
+        goal: 2,
+        startBucket: One,
+    }
+    expected = {
+        moves: 14,
+        goalBucket: One,
+        otherBucket: 11,
+    }
+    result == expected
+
+# Measure using bucket one of size 7 and bucket two of size 11 - start with bucket two
+expect
+    result = measure {
+        bucketOne: 7,
+        bucketTwo: 11,
+        goal: 2,
+        startBucket: Two,
+    }
+    expected = {
+        moves: 18,
+        goalBucket: Two,
+        otherBucket: 7,
+    }
+    result == expected
+
+# Measure one step using bucket one of size 1 and bucket two of size 3 - start with bucket two
+expect
+    result = measure {
+        bucketOne: 1,
+        bucketTwo: 3,
+        goal: 3,
+        startBucket: Two,
+    }
+    expected = {
+        moves: 1,
+        goalBucket: Two,
+        otherBucket: 0,
+    }
+    result == expected
+
+# Measure using bucket one of size 2 and bucket two of size 3 - start with bucket one and end with bucket two
+expect
+    result = measure {
+        bucketOne: 2,
+        bucketTwo: 3,
+        goal: 3,
+        startBucket: One,
+    }
+    expected = {
+        moves: 2,
+        goalBucket: Two,
+        otherBucket: 2,
+    }
+    result == expected
+
+# Not possible to reach the goal
+expect
+    result = measure {
+        bucketOne: 6,
+        bucketTwo: 15,
+        goal: 5,
+        startBucket: One,
+    }
+    result |> Result.isErr
+
+# With the same buckets but a different goal, then it is possible
+expect
+    result = measure {
+        bucketOne: 6,
+        bucketTwo: 15,
+        goal: 9,
+        startBucket: One,
+    }
+    expected = {
+        moves: 10,
+        goalBucket: Two,
+        otherBucket: 0,
+    }
+    result == expected
+
+# Goal larger than both buckets is impossible
+expect
+    result = measure {
+        bucketOne: 5,
+        bucketTwo: 7,
+        goal: 8,
+        startBucket: One,
+    }
+    result |> Result.isErr
+


### PR DESCRIPTION
That was a fun exercise!

For the solution, I wrote a general-purpose BFS implementation. The advantage is that it can be reused in other exercises (e.g., it would have been handy for the `connect` exercise). The main downsides are:
* the `bfs` function outputs the shortest path even though all we really need is the _length_ of the shortest path
* as a result, the solution is a bit longer than it could be
* and the type annotations of the `bfs` function could potentially be confusing to beginners

I don't think these downsides matter much, given that the `.meta/Example.roc` file is not shown to the end user, it's mostly there to ensure that the tests work well. Moreover, this exercise has difficulty 6, so it's not really meant for complete beginners, we can assume they understand type annotations by now.

Wdyt?