### PR TITLE
Use Grapheme module instead of CodePoint

### DIFF
--- a/exercises/practice/micro-blog/.meta/Example.roc
+++ b/exercises/practice/micro-blog/.meta/Example.roc
@@ -1,10 +1,20 @@
 module [truncate]
 
-import unicode.CodePoint
+import unicode.Grapheme
 
-truncate : Str -> Result Str _
+GraphemeErrors : [
+    CodepointTooLarge,
+    EncodesSurrogateHalf,
+    ExpectedContinuation,
+    InvalidUtf8,
+    ListWasEmpty,
+    OverlongEncoding,
+]
+
+truncate : Str -> Result Str GraphemeErrors
 truncate = \input ->
-    Str.toUtf8 input
-        |> CodePoint.parseUtf8?
+    input
+        |> Grapheme.split?
         |> List.takeFirst 5
-        |> CodePoint.toStr
+        |> Str.joinWith ""
+        |> Ok

--- a/exercises/practice/micro-blog/MicroBlog.roc
+++ b/exercises/practice/micro-blog/MicroBlog.roc
@@ -1,6 +1,6 @@
 module [truncate]
 
-import unicode.CodePoint
+import unicode.Grapheme
 
 truncate : Str -> Result Str _
 truncate = \input ->


### PR DESCRIPTION
What we humans consider as a "character" is what Unicode calls a "grapheme". Most graphemes are composed of a single Unicode code-point, but many are composed of more than one, for example most flags (e.g., 🇫🇷🏴‍☠️🏁🎌🚩🏳️‍🌈) and many characters with multiple diacritics (e.g., ắ or न).

This exercise only tests for graphemes composed of a single code-point, therefore using `CodePoint.fromUtf8` works, but I think it would be preferable to encourage users to use `Grapheme.split` instead, or else they'll run into surprising issues one day when they run into "long" graphemes.