### PR TITLE
Add custom-set exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -340,6 +340,14 @@
         "difficulty": 3
       },
       {
+        "slug": "custom-set",
+        "name": "Custom Set",
+        "uuid": "cad7b3db-6fdc-4df0-90da-3799d4a0e440",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
         "slug": "diamond",
         "name": "Diamond",
         "uuid": "019e2937-b786-4825-9a61-8f462ddb3899",

--- a/config.json
+++ b/config.json
@@ -340,14 +340,6 @@
         "difficulty": 3
       },
       {
-        "slug": "custom-set",
-        "name": "Custom Set",
-        "uuid": "cad7b3db-6fdc-4df0-90da-3799d4a0e440",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 3
-      },
-      {
         "slug": "diamond",
         "name": "Diamond",
         "uuid": "019e2937-b786-4825-9a61-8f462ddb3899",
@@ -543,6 +535,14 @@
         "slug": "anagram",
         "name": "Anagram",
         "uuid": "40942be8-7c32-4da3-acff-a2365087cd5d",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 4
+      },
+      {
+        "slug": "custom-set",
+        "name": "Custom Set",
+        "uuid": "cad7b3db-6fdc-4df0-90da-3799d4a0e440",
         "practices": [],
         "prerequisites": [],
         "difficulty": 4

--- a/exercises/practice/custom-set/.docs/instructions.md
+++ b/exercises/practice/custom-set/.docs/instructions.md
@@ -1,0 +1,7 @@
+# Instructions
+
+Create a custom set type.
+
+Sometimes it is necessary to define a custom data structure of some type, like a set.
+In this exercise you will define your own set.
+How it works internally doesn't matter, as long as it behaves like a set of unique elements.

--- a/exercises/practice/custom-set/.meta/Example.roc
+++ b/exercises/practice/custom-set/.meta/Example.roc
@@ -43,7 +43,10 @@ fromList = \list ->
 
 insert : CustomSet, Element -> CustomSet
 insert = \@CustomSet { items }, element ->
-    items |> List.append element |> List.sortAsc |> fromList
+    if items |> List.contains element then
+        @CustomSet { items }
+    else
+        @CustomSet { items: items |> List.append element }
 
 intersection : CustomSet, CustomSet -> CustomSet
 intersection = \@CustomSet { items: items1 }, @CustomSet { items: items2 } ->
@@ -60,7 +63,7 @@ isEmpty = \@CustomSet { items } ->
 
 isEq : CustomSet, CustomSet -> Bool
 isEq = \@CustomSet { items: items1 }, @CustomSet { items: items2 } ->
-    items1 == items2 # items list is always sorted
+    items1 |> List.sortAsc == items2 |> List.sortAsc
 
 isSubsetOf : CustomSet, CustomSet -> Bool
 isSubsetOf = \@CustomSet { items: items1 }, @CustomSet { items: items2 } ->

--- a/exercises/practice/custom-set/.meta/Example.roc
+++ b/exercises/practice/custom-set/.meta/Example.roc
@@ -1,0 +1,75 @@
+module [
+    contains,
+    difference,
+    fromList,
+    insert,
+    intersection,
+    isDisjointWith,
+    isEmpty,
+    isEq,
+    isSubsetOf,
+    toList,
+    toList,
+    union,
+]
+
+Element : U64
+
+CustomSet := { items : List Element } implements [Eq]
+
+contains : CustomSet, Element -> Bool
+contains = \@CustomSet { items }, element ->
+    items |> List.contains element
+
+difference : CustomSet, CustomSet -> CustomSet
+difference = \@CustomSet { items: items1 }, @CustomSet { items: items2 } ->
+    items = items1 |> List.dropIf \item -> items2 |> List.contains item
+    @CustomSet { items }
+
+fromList : List Element -> CustomSet
+fromList = \list ->
+    when list |> List.sortAsc is
+        [] -> @CustomSet { items: [] }
+        [first, .. as rest] ->
+            items =
+                rest
+                |> List.walk { items: [first], previous: first } \state, item ->
+                    if item == state.previous then
+                        state
+                    else
+                        { items: state.items |> List.append item, previous: item }
+                |> .items
+            @CustomSet { items }
+
+insert : CustomSet, Element -> CustomSet
+insert = \@CustomSet { items }, element ->
+    items |> List.append element |> List.sortAsc |> fromList
+
+intersection : CustomSet, CustomSet -> CustomSet
+intersection = \@CustomSet { items: items1 }, @CustomSet { items: items2 } ->
+    items = items1 |> List.keepIf \item -> items2 |> List.contains item
+    @CustomSet { items }
+
+isDisjointWith : CustomSet, CustomSet -> Bool
+isDisjointWith = \set1, set2 ->
+    set1 |> intersection set2 |> isEmpty
+
+isEmpty : CustomSet -> Bool
+isEmpty = \@CustomSet { items } ->
+    items |> List.isEmpty
+
+isEq : CustomSet, CustomSet -> Bool
+isEq = \@CustomSet { items: items1 }, @CustomSet { items: items2 } ->
+    items1 == items2 # items list is always sorted
+
+isSubsetOf : CustomSet, CustomSet -> Bool
+isSubsetOf = \@CustomSet { items: items1 }, @CustomSet { items: items2 } ->
+    items1 |> List.all \item -> items2 |> List.contains item
+
+toList : CustomSet -> List Element
+toList = \@CustomSet { items } ->
+    items
+
+union : CustomSet, CustomSet -> CustomSet
+union = \set1, set2 ->
+    set1 |> toList |> List.concat (set2 |> toList) |> fromList

--- a/exercises/practice/custom-set/.meta/additional_tests.json
+++ b/exercises/practice/custom-set/.meta/additional_tests.json
@@ -1,0 +1,28 @@
+{
+  "cases": [
+    {
+      "description": "an empty set has an empty list of items",
+      "property": "toList",
+      "input": {
+        "set": []
+      },
+      "expected": []
+    },
+    {
+      "description": "a set can provide the list of its items",
+      "property": "toList",
+      "input": {
+        "set": [1, 2, 3, 4]
+      },
+      "expected": [1, 2, 3, 4]
+    },
+    {
+      "description": "duplicate items must be removed",
+      "property": "toList",
+      "input": {
+        "set": [1, 2, 2, 3, 3, 3, 4, 4, 4, 4]
+      },
+      "expected": [1, 2, 3, 4]
+    }
+  ]
+}

--- a/exercises/practice/custom-set/.meta/config.json
+++ b/exercises/practice/custom-set/.meta/config.json
@@ -1,0 +1,17 @@
+{
+  "authors": [
+    "ageron"
+  ],
+  "files": {
+    "solution": [
+      "CustomSet.roc"
+    ],
+    "test": [
+      "custom-set-test.roc"
+    ],
+    "example": [
+      ".meta/Example.roc"
+    ]
+  },
+  "blurb": "Create a custom set type."
+}

--- a/exercises/practice/custom-set/.meta/template.j2
+++ b/exercises/practice/custom-set/.meta/template.j2
@@ -46,10 +46,11 @@ expect
     {%- endif %}
     {%- if case["expected"] is iterable %}
     expected = {{ case["expected"] | to_roc }} |> fromList
+    result |> isEq expected
     {%- else %}
     expected = {{ case["expected"] | to_roc }}
-    {%- endif %}
     result == expected
+    {%- endif %}
 
 {% endfor %}
 {% endfor %}

--- a/exercises/practice/custom-set/.meta/template.j2
+++ b/exercises/practice/custom-set/.meta/template.j2
@@ -1,0 +1,69 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+{{ macros.header() }}
+
+import {{ exercise | to_pascal }} exposing [
+    contains,
+    difference,
+    fromList,
+    insert,
+    intersection,
+    isDisjointWith,
+    isEmpty,
+    isEq,
+    isSubsetOf,
+    toList,
+    union,
+]
+
+{%
+set property_map = {
+    "add": "insert",
+    "disjoint": "isDisjointWith",
+    "empty": "isEmpty",
+    "equal": "isEq",
+    "subset": "isSubsetOf",
+}
+%}
+
+{% for supercase in cases %}
+##
+## {{ supercase["description"] }}
+##
+
+{% for case in supercase["cases"] -%}
+# {{ case["description"] }}
+{% set property = property_map.get(case["property"], case["property"]) %}
+expect
+    {%- if "set" in case["input"] %}
+    set = fromList {{ case["input"]["set"] | to_roc }}
+    result = set |> {{ property | to_camel }}
+    {%- if "element" in case["input"] %} {{ case["input"]["element"] }}{%- endif %}
+    {%- else %}
+    set1 = fromList {{ case["input"]["set1"] | to_roc }}
+    set2 = fromList {{ case["input"]["set2"] | to_roc }}
+    result = set1 |> {{ property | to_camel }} set2
+    {%- endif %}
+    {%- if case["expected"] is iterable %}
+    expected = {{ case["expected"] | to_roc }} |> fromList
+    {%- else %}
+    expected = {{ case["expected"] | to_roc }}
+    {%- endif %}
+    result == expected
+
+{% endfor %}
+{% endfor %}
+
+##
+## A set can be converted to a list of items
+##
+
+{% for case in additional_cases -%}
+# {{ case["description"] }}
+expect
+    set = fromList {{ case["input"]["set"] | to_roc }}
+    result = set |> toList |> List.sortAsc
+    expected = {{ case["expected"] | to_roc }}
+    result == expected
+
+{% endfor %}

--- a/exercises/practice/custom-set/.meta/tests.toml
+++ b/exercises/practice/custom-set/.meta/tests.toml
@@ -1,0 +1,130 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[20c5f855-f83a-44a7-abdd-fe75c6cf022b]
+description = "Returns true if the set contains no elements -> sets with no elements are empty"
+
+[d506485d-5706-40db-b7d8-5ceb5acf88d2]
+description = "Returns true if the set contains no elements -> sets with elements are not empty"
+
+[759b9740-3417-44c3-8ca3-262b3c281043]
+description = "Sets can report if they contain an element -> nothing is contained in an empty set"
+
+[f83cd2d1-2a85-41bc-b6be-80adbff4be49]
+description = "Sets can report if they contain an element -> when the element is in the set"
+
+[93423fc0-44d0-4bc0-a2ac-376de8d7af34]
+description = "Sets can report if they contain an element -> when the element is not in the set"
+
+[c392923a-637b-4495-b28e-34742cd6157a]
+description = "A set is a subset if all of its elements are contained in the other set -> empty set is a subset of another empty set"
+
+[5635b113-be8c-4c6f-b9a9-23c485193917]
+description = "A set is a subset if all of its elements are contained in the other set -> empty set is a subset of non-empty set"
+
+[832eda58-6d6e-44e2-92c2-be8cf0173cee]
+description = "A set is a subset if all of its elements are contained in the other set -> non-empty set is not a subset of empty set"
+
+[c830c578-8f97-4036-b082-89feda876131]
+description = "A set is a subset if all of its elements are contained in the other set -> set is a subset of set with exact same elements"
+
+[476a4a1c-0fd1-430f-aa65-5b70cbc810c5]
+description = "A set is a subset if all of its elements are contained in the other set -> set is a subset of larger set with same elements"
+
+[d2498999-3e46-48e4-9660-1e20c3329d3d]
+description = "A set is a subset if all of its elements are contained in the other set -> set is not a subset of set that does not contain its elements"
+
+[7d38155e-f472-4a7e-9ad8-5c1f8f95e4cc]
+description = "Sets are disjoint if they share no elements -> the empty set is disjoint with itself"
+
+[7a2b3938-64b6-4b32-901a-fe16891998a6]
+description = "Sets are disjoint if they share no elements -> empty set is disjoint with non-empty set"
+
+[589574a0-8b48-48ea-88b0-b652c5fe476f]
+description = "Sets are disjoint if they share no elements -> non-empty set is disjoint with empty set"
+
+[febeaf4f-f180-4499-91fa-59165955a523]
+description = "Sets are disjoint if they share no elements -> sets are not disjoint if they share an element"
+
+[0de20d2f-c952-468a-88c8-5e056740f020]
+description = "Sets are disjoint if they share no elements -> sets are disjoint if they share no elements"
+
+[4bd24adb-45da-4320-9ff6-38c044e9dff8]
+description = "Sets with the same elements are equal -> empty sets are equal"
+
+[f65c0a0e-6632-4b2d-b82c-b7c6da2ec224]
+description = "Sets with the same elements are equal -> empty set is not equal to non-empty set"
+
+[81e53307-7683-4b1e-a30c-7e49155fe3ca]
+description = "Sets with the same elements are equal -> non-empty set is not equal to empty set"
+
+[d57c5d7c-a7f3-48cc-a162-6b488c0fbbd0]
+description = "Sets with the same elements are equal -> sets with the same elements are equal"
+
+[dd61bafc-6653-42cc-961a-ab071ee0ee85]
+description = "Sets with the same elements are equal -> sets with different elements are not equal"
+
+[06059caf-9bf4-425e-aaff-88966cb3ea14]
+description = "Sets with the same elements are equal -> set is not equal to larger set with same elements"
+
+[d4a1142f-09aa-4df9-8b83-4437dcf7ec24]
+description = "Sets with the same elements are equal -> set is equal to a set constructed from an array with duplicates"
+
+[8a677c3c-a658-4d39-bb88-5b5b1a9659f4]
+description = "Unique elements can be added to a set -> add to empty set"
+
+[0903dd45-904d-4cf2-bddd-0905e1a8d125]
+description = "Unique elements can be added to a set -> add to non-empty set"
+
+[b0eb7bb7-5e5d-4733-b582-af771476cb99]
+description = "Unique elements can be added to a set -> adding an existing element does not change the set"
+
+[893d5333-33b8-4151-a3d4-8f273358208a]
+description = "Intersection returns a set of all shared elements -> intersection of two empty sets is an empty set"
+
+[d739940e-def2-41ab-a7bb-aaf60f7d782c]
+description = "Intersection returns a set of all shared elements -> intersection of an empty set and non-empty set is an empty set"
+
+[3607d9d8-c895-4d6f-ac16-a14956e0a4b7]
+description = "Intersection returns a set of all shared elements -> intersection of a non-empty set and an empty set is an empty set"
+
+[b5120abf-5b5e-41ab-aede-4de2ad85c34e]
+description = "Intersection returns a set of all shared elements -> intersection of two sets with no shared elements is an empty set"
+
+[af21ca1b-fac9-499c-81c0-92a591653d49]
+description = "Intersection returns a set of all shared elements -> intersection of two sets with shared elements is a set of the shared elements"
+
+[c5e6e2e4-50e9-4bc2-b89f-c518f015b57e]
+description = "Difference (or Complement) of a set is a set of all elements that are only in the first set -> difference of two empty sets is an empty set"
+
+[2024cc92-5c26-44ed-aafd-e6ca27d6fcd2]
+description = "Difference (or Complement) of a set is a set of all elements that are only in the first set -> difference of empty set and non-empty set is an empty set"
+
+[e79edee7-08aa-4c19-9382-f6820974b43e]
+description = "Difference (or Complement) of a set is a set of all elements that are only in the first set -> difference of a non-empty set and an empty set is the non-empty set"
+
+[c5ac673e-d707-4db5-8d69-7082c3a5437e]
+description = "Difference (or Complement) of a set is a set of all elements that are only in the first set -> difference of two non-empty sets is a set of elements that are only in the first set"
+
+[20d0a38f-7bb7-4c4a-ac15-90c7392ecf2b]
+description = "Difference (or Complement) of a set is a set of all elements that are only in the first set -> difference removes all duplicates in the first set"
+
+[c45aed16-5494-455a-9033-5d4c93589dc6]
+description = "Union returns a set of all elements in either set -> union of empty sets is an empty set"
+
+[9d258545-33c2-4fcb-a340-9f8aa69e7a41]
+description = "Union returns a set of all elements in either set -> union of an empty set and non-empty set is the non-empty set"
+
+[3aade50c-80c7-4db8-853d-75bac5818b83]
+description = "Union returns a set of all elements in either set -> union of a non-empty set and empty set is the non-empty set"
+
+[a00bb91f-c4b4-4844-8f77-c73e2e9df77c]
+description = "Union returns a set of all elements in either set -> union of non-empty sets contains all unique elements"

--- a/exercises/practice/custom-set/CustomSet.roc
+++ b/exercises/practice/custom-set/CustomSet.roc
@@ -1,0 +1,68 @@
+module [
+    contains,
+    difference,
+    fromList,
+    insert,
+    intersection,
+    isDisjointWith,
+    isEmpty,
+    isEq,
+    isSubsetOf,
+    toList,
+    union,
+]
+
+Element : U64
+
+CustomSet := {
+    # TODO: change this opaque type however you need
+    todo : U64,
+    todo2 : U64,
+    todo3 : U64,
+    # etc.
+}
+    implements [] # TODO: implement the appropriate abilities
+
+contains : CustomSet, Element -> Bool
+contains = \set, element ->
+    crash "Please implement the 'contains' function"
+
+difference : CustomSet, CustomSet -> CustomSet
+difference = \set1, set2 ->
+    crash "Please implement the 'difference' function"
+
+fromList : List Element -> CustomSet
+fromList = \list ->
+    crash "Please implement the 'fromList' function"
+
+insert : CustomSet, Element -> CustomSet
+insert = \set, element ->
+    crash "Please implement the 'insert' function"
+
+intersection : CustomSet, CustomSet -> CustomSet
+intersection = \set1, set2 ->
+    crash "Please implement the 'intersection' function"
+
+isDisjointWith : CustomSet, CustomSet -> Bool
+isDisjointWith = \set1, set2 ->
+    crash "Please implement the 'isDisjointWith' function"
+
+isEmpty : CustomSet -> Bool
+isEmpty = \set ->
+    crash "Please implement the 'isEmpty' function"
+
+isEq : CustomSet, CustomSet -> Bool
+isEq = \set1, set2 ->
+    crash "Please implement the 'isEq' function"
+
+isSubsetOf : CustomSet, CustomSet -> Bool
+isSubsetOf = \set1, set2 ->
+    crash "Please implement the 'isSubsetOf' function"
+
+toList : CustomSet -> List Element
+toList = \set ->
+    crash "Please implement the 'toList' function"
+
+union : CustomSet, CustomSet -> CustomSet
+union = \set1, set2 ->
+    crash "Please implement the 'union' function"

--- a/exercises/practice/custom-set/CustomSet.roc
+++ b/exercises/practice/custom-set/CustomSet.roc
@@ -21,7 +21,7 @@ CustomSet := {
     todo3 : U64,
     # etc.
 }
-    implements [] # TODO: implement the appropriate abilities
+    implements [Eq]
 
 contains : CustomSet, Element -> Bool
 contains = \set, element ->

--- a/exercises/practice/custom-set/custom-set-test.roc
+++ b/exercises/practice/custom-set/custom-set-test.roc
@@ -1,0 +1,437 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/custom-set/canonical-data.json
+# File last updated on 2024-10-11
+app [main] {
+    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br",
+}
+
+main =
+    Task.ok {}
+
+import CustomSet exposing [
+    contains,
+    difference,
+    fromList,
+    insert,
+    intersection,
+    isDisjointWith,
+    isEmpty,
+    isEq,
+    isSubsetOf,
+    toList,
+    union,
+]
+
+##
+## Returns true if the set contains no elements
+##
+
+# sets with no elements are empty
+
+expect
+    set = fromList []
+    result = set |> isEmpty
+    expected = Bool.true
+    result == expected
+
+# sets with elements are not empty
+
+expect
+    set = fromList [1]
+    result = set |> isEmpty
+    expected = Bool.false
+    result == expected
+
+##
+## Sets can report if they contain an element
+##
+
+# nothing is contained in an empty set
+
+expect
+    set = fromList []
+    result = set |> contains 1
+    expected = Bool.false
+    result == expected
+
+# when the element is in the set
+
+expect
+    set = fromList [1, 2, 3]
+    result = set |> contains 1
+    expected = Bool.true
+    result == expected
+
+# when the element is not in the set
+
+expect
+    set = fromList [1, 2, 3]
+    result = set |> contains 4
+    expected = Bool.false
+    result == expected
+
+##
+## A set is a subset if all of its elements are contained in the other set
+##
+
+# empty set is a subset of another empty set
+
+expect
+    set1 = fromList []
+    set2 = fromList []
+    result = set1 |> isSubsetOf set2
+    expected = Bool.true
+    result == expected
+
+# empty set is a subset of non-empty set
+
+expect
+    set1 = fromList []
+    set2 = fromList [1]
+    result = set1 |> isSubsetOf set2
+    expected = Bool.true
+    result == expected
+
+# non-empty set is not a subset of empty set
+
+expect
+    set1 = fromList [1]
+    set2 = fromList []
+    result = set1 |> isSubsetOf set2
+    expected = Bool.false
+    result == expected
+
+# set is a subset of set with exact same elements
+
+expect
+    set1 = fromList [1, 2, 3]
+    set2 = fromList [1, 2, 3]
+    result = set1 |> isSubsetOf set2
+    expected = Bool.true
+    result == expected
+
+# set is a subset of larger set with same elements
+
+expect
+    set1 = fromList [1, 2, 3]
+    set2 = fromList [4, 1, 2, 3]
+    result = set1 |> isSubsetOf set2
+    expected = Bool.true
+    result == expected
+
+# set is not a subset of set that does not contain its elements
+
+expect
+    set1 = fromList [1, 2, 3]
+    set2 = fromList [4, 1, 3]
+    result = set1 |> isSubsetOf set2
+    expected = Bool.false
+    result == expected
+
+##
+## Sets are disjoint if they share no elements
+##
+
+# the empty set is disjoint with itself
+
+expect
+    set1 = fromList []
+    set2 = fromList []
+    result = set1 |> isDisjointWith set2
+    expected = Bool.true
+    result == expected
+
+# empty set is disjoint with non-empty set
+
+expect
+    set1 = fromList []
+    set2 = fromList [1]
+    result = set1 |> isDisjointWith set2
+    expected = Bool.true
+    result == expected
+
+# non-empty set is disjoint with empty set
+
+expect
+    set1 = fromList [1]
+    set2 = fromList []
+    result = set1 |> isDisjointWith set2
+    expected = Bool.true
+    result == expected
+
+# sets are not disjoint if they share an element
+
+expect
+    set1 = fromList [1, 2]
+    set2 = fromList [2, 3]
+    result = set1 |> isDisjointWith set2
+    expected = Bool.false
+    result == expected
+
+# sets are disjoint if they share no elements
+
+expect
+    set1 = fromList [1, 2]
+    set2 = fromList [3, 4]
+    result = set1 |> isDisjointWith set2
+    expected = Bool.true
+    result == expected
+
+##
+## Sets with the same elements are equal
+##
+
+# empty sets are equal
+
+expect
+    set1 = fromList []
+    set2 = fromList []
+    result = set1 |> isEq set2
+    expected = Bool.true
+    result == expected
+
+# empty set is not equal to non-empty set
+
+expect
+    set1 = fromList []
+    set2 = fromList [1, 2, 3]
+    result = set1 |> isEq set2
+    expected = Bool.false
+    result == expected
+
+# non-empty set is not equal to empty set
+
+expect
+    set1 = fromList [1, 2, 3]
+    set2 = fromList []
+    result = set1 |> isEq set2
+    expected = Bool.false
+    result == expected
+
+# sets with the same elements are equal
+
+expect
+    set1 = fromList [1, 2]
+    set2 = fromList [2, 1]
+    result = set1 |> isEq set2
+    expected = Bool.true
+    result == expected
+
+# sets with different elements are not equal
+
+expect
+    set1 = fromList [1, 2, 3]
+    set2 = fromList [1, 2, 4]
+    result = set1 |> isEq set2
+    expected = Bool.false
+    result == expected
+
+# set is not equal to larger set with same elements
+
+expect
+    set1 = fromList [1, 2, 3]
+    set2 = fromList [1, 2, 3, 4]
+    result = set1 |> isEq set2
+    expected = Bool.false
+    result == expected
+
+# set is equal to a set constructed from an array with duplicates
+
+expect
+    set1 = fromList [1]
+    set2 = fromList [1, 1]
+    result = set1 |> isEq set2
+    expected = Bool.true
+    result == expected
+
+##
+## Unique elements can be added to a set
+##
+
+# add to empty set
+
+expect
+    set = fromList []
+    result = set |> insert 3
+    expected = [3] |> fromList
+    result == expected
+
+# add to non-empty set
+
+expect
+    set = fromList [1, 2, 4]
+    result = set |> insert 3
+    expected = [1, 2, 3, 4] |> fromList
+    result == expected
+
+# adding an existing element does not change the set
+
+expect
+    set = fromList [1, 2, 3]
+    result = set |> insert 3
+    expected = [1, 2, 3] |> fromList
+    result == expected
+
+##
+## Intersection returns a set of all shared elements
+##
+
+# intersection of two empty sets is an empty set
+
+expect
+    set1 = fromList []
+    set2 = fromList []
+    result = set1 |> intersection set2
+    expected = [] |> fromList
+    result == expected
+
+# intersection of an empty set and non-empty set is an empty set
+
+expect
+    set1 = fromList []
+    set2 = fromList [3, 2, 5]
+    result = set1 |> intersection set2
+    expected = [] |> fromList
+    result == expected
+
+# intersection of a non-empty set and an empty set is an empty set
+
+expect
+    set1 = fromList [1, 2, 3, 4]
+    set2 = fromList []
+    result = set1 |> intersection set2
+    expected = [] |> fromList
+    result == expected
+
+# intersection of two sets with no shared elements is an empty set
+
+expect
+    set1 = fromList [1, 2, 3]
+    set2 = fromList [4, 5, 6]
+    result = set1 |> intersection set2
+    expected = [] |> fromList
+    result == expected
+
+# intersection of two sets with shared elements is a set of the shared elements
+
+expect
+    set1 = fromList [1, 2, 3, 4]
+    set2 = fromList [3, 2, 5]
+    result = set1 |> intersection set2
+    expected = [2, 3] |> fromList
+    result == expected
+
+##
+## Difference (or Complement) of a set is a set of all elements that are only in the first set
+##
+
+# difference of two empty sets is an empty set
+
+expect
+    set1 = fromList []
+    set2 = fromList []
+    result = set1 |> difference set2
+    expected = [] |> fromList
+    result == expected
+
+# difference of empty set and non-empty set is an empty set
+
+expect
+    set1 = fromList []
+    set2 = fromList [3, 2, 5]
+    result = set1 |> difference set2
+    expected = [] |> fromList
+    result == expected
+
+# difference of a non-empty set and an empty set is the non-empty set
+
+expect
+    set1 = fromList [1, 2, 3, 4]
+    set2 = fromList []
+    result = set1 |> difference set2
+    expected = [1, 2, 3, 4] |> fromList
+    result == expected
+
+# difference of two non-empty sets is a set of elements that are only in the first set
+
+expect
+    set1 = fromList [3, 2, 1]
+    set2 = fromList [2, 4]
+    result = set1 |> difference set2
+    expected = [1, 3] |> fromList
+    result == expected
+
+# difference removes all duplicates in the first set
+
+expect
+    set1 = fromList [1, 1]
+    set2 = fromList [1]
+    result = set1 |> difference set2
+    expected = [] |> fromList
+    result == expected
+
+##
+## Union returns a set of all elements in either set
+##
+
+# union of empty sets is an empty set
+
+expect
+    set1 = fromList []
+    set2 = fromList []
+    result = set1 |> union set2
+    expected = [] |> fromList
+    result == expected
+
+# union of an empty set and non-empty set is the non-empty set
+
+expect
+    set1 = fromList []
+    set2 = fromList [2]
+    result = set1 |> union set2
+    expected = [2] |> fromList
+    result == expected
+
+# union of a non-empty set and empty set is the non-empty set
+
+expect
+    set1 = fromList [1, 3]
+    set2 = fromList []
+    result = set1 |> union set2
+    expected = [1, 3] |> fromList
+    result == expected
+
+# union of non-empty sets contains all unique elements
+
+expect
+    set1 = fromList [1, 3]
+    set2 = fromList [2, 3]
+    result = set1 |> union set2
+    expected = [3, 2, 1] |> fromList
+    result == expected
+
+##
+## A set can be converted to a list of items
+##
+
+# an empty set has an empty list of items
+expect
+    set = fromList []
+    result = set |> toList |> List.sortAsc
+    expected = []
+    result == expected
+
+# a set can provide the list of its items
+expect
+    set = fromList [1, 2, 3, 4]
+    result = set |> toList |> List.sortAsc
+    expected = [1, 2, 3, 4]
+    result == expected
+
+# duplicate items must be removed
+expect
+    set = fromList [1, 2, 2, 3, 3, 3, 4, 4, 4, 4]
+    result = set |> toList |> List.sortAsc
+    expected = [1, 2, 3, 4]
+    result == expected
+

--- a/exercises/practice/custom-set/custom-set-test.roc
+++ b/exercises/practice/custom-set/custom-set-test.roc
@@ -254,7 +254,7 @@ expect
     set = fromList []
     result = set |> insert 3
     expected = [3] |> fromList
-    result == expected
+    result |> isEq expected
 
 # add to non-empty set
 
@@ -262,7 +262,7 @@ expect
     set = fromList [1, 2, 4]
     result = set |> insert 3
     expected = [1, 2, 3, 4] |> fromList
-    result == expected
+    result |> isEq expected
 
 # adding an existing element does not change the set
 
@@ -270,7 +270,7 @@ expect
     set = fromList [1, 2, 3]
     result = set |> insert 3
     expected = [1, 2, 3] |> fromList
-    result == expected
+    result |> isEq expected
 
 ##
 ## Intersection returns a set of all shared elements
@@ -283,7 +283,7 @@ expect
     set2 = fromList []
     result = set1 |> intersection set2
     expected = [] |> fromList
-    result == expected
+    result |> isEq expected
 
 # intersection of an empty set and non-empty set is an empty set
 
@@ -292,7 +292,7 @@ expect
     set2 = fromList [3, 2, 5]
     result = set1 |> intersection set2
     expected = [] |> fromList
-    result == expected
+    result |> isEq expected
 
 # intersection of a non-empty set and an empty set is an empty set
 
@@ -301,7 +301,7 @@ expect
     set2 = fromList []
     result = set1 |> intersection set2
     expected = [] |> fromList
-    result == expected
+    result |> isEq expected
 
 # intersection of two sets with no shared elements is an empty set
 
@@ -310,7 +310,7 @@ expect
     set2 = fromList [4, 5, 6]
     result = set1 |> intersection set2
     expected = [] |> fromList
-    result == expected
+    result |> isEq expected
 
 # intersection of two sets with shared elements is a set of the shared elements
 
@@ -319,7 +319,7 @@ expect
     set2 = fromList [3, 2, 5]
     result = set1 |> intersection set2
     expected = [2, 3] |> fromList
-    result == expected
+    result |> isEq expected
 
 ##
 ## Difference (or Complement) of a set is a set of all elements that are only in the first set
@@ -332,7 +332,7 @@ expect
     set2 = fromList []
     result = set1 |> difference set2
     expected = [] |> fromList
-    result == expected
+    result |> isEq expected
 
 # difference of empty set and non-empty set is an empty set
 
@@ -341,7 +341,7 @@ expect
     set2 = fromList [3, 2, 5]
     result = set1 |> difference set2
     expected = [] |> fromList
-    result == expected
+    result |> isEq expected
 
 # difference of a non-empty set and an empty set is the non-empty set
 
@@ -350,7 +350,7 @@ expect
     set2 = fromList []
     result = set1 |> difference set2
     expected = [1, 2, 3, 4] |> fromList
-    result == expected
+    result |> isEq expected
 
 # difference of two non-empty sets is a set of elements that are only in the first set
 
@@ -359,7 +359,7 @@ expect
     set2 = fromList [2, 4]
     result = set1 |> difference set2
     expected = [1, 3] |> fromList
-    result == expected
+    result |> isEq expected
 
 # difference removes all duplicates in the first set
 
@@ -368,7 +368,7 @@ expect
     set2 = fromList [1]
     result = set1 |> difference set2
     expected = [] |> fromList
-    result == expected
+    result |> isEq expected
 
 ##
 ## Union returns a set of all elements in either set
@@ -381,7 +381,7 @@ expect
     set2 = fromList []
     result = set1 |> union set2
     expected = [] |> fromList
-    result == expected
+    result |> isEq expected
 
 # union of an empty set and non-empty set is the non-empty set
 
@@ -390,7 +390,7 @@ expect
     set2 = fromList [2]
     result = set1 |> union set2
     expected = [2] |> fromList
-    result == expected
+    result |> isEq expected
 
 # union of a non-empty set and empty set is the non-empty set
 
@@ -399,7 +399,7 @@ expect
     set2 = fromList []
     result = set1 |> union set2
     expected = [1, 3] |> fromList
-    result == expected
+    result |> isEq expected
 
 # union of non-empty sets contains all unique elements
 
@@ -408,7 +408,7 @@ expect
     set2 = fromList [2, 3]
     result = set1 |> union set2
     expected = [3, 2, 1] |> fromList
-    result == expected
+    result |> isEq expected
 
 ##
 ## A set can be converted to a list of items


### PR DESCRIPTION
I set the difficulty to 3 because almost all functions are trivial except `fromList` which must get rid of duplicates. Perhaps it should be difficulty 4, please let me know what you think.

Also note that I focused the solution on simplicity, not performance. I considered implementing the list of items as a hash table or a sorted binary tree, but I decided that the objective of the `Example.roc` code is to ensure that the tests work well in the simplest way possible.

Also, the stub contains this code:

```roc
CustomSet := {
    # TODO: change this opaque type however you need
    todo : U64,
    todo2 : U64,
    todo3 : U64,
    # etc.
}
    implements [Eq]
```

The tests initially used `==` to compare `CustomSet` values, but this actually did not call `isEq`, so the tests would fail if the items inside the set were not in the same order. This is due to https://github.com/roc-lang/roc/issues/7111. So I temporarily replaced `==` with `isEq` in the tests, but I left `implements [Eq]` in the stub and solution, so that we can easily change the tests back to `==` when the issue is fixed.