### PR TITLE
Add additional tests to clock exercise for extreme I64 values, fixes #150

### DIFF
--- a/config.json
+++ b/config.json
@@ -98,14 +98,6 @@
         "status": "deprecated"
       },
       {
-        "slug": "clock",
-        "name": "Clock",
-        "uuid": "b1ebc201-5d23-4953-88d7-58c82def95b3",
-        "practices": [],
-        "prerequisites": [],
-        "difficulty": 2
-      },
-      {
         "slug": "collatz-conjecture",
         "name": "Collatz Conjecture",
         "uuid": "39d17f08-a506-4d0e-8846-34e7c622160b",
@@ -327,6 +319,14 @@
         "slug": "bob",
         "name": "Bob",
         "uuid": "80a035ed-e6d2-47de-ab12-5711cc39bee5",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 3
+      },
+      {
+        "slug": "clock",
+        "name": "Clock",
+        "uuid": "b1ebc201-5d23-4953-88d7-58c82def95b3",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3

--- a/exercises/practice/clock/.meta/Example.roc
+++ b/exercises/practice/clock/.meta/Example.roc
@@ -6,7 +6,9 @@ minutesPerDay = 24 * 60
 
 create : { hours ? I64, minutes ? I64 }* -> Clock
 create = \{ hours ? 0, minutes ? 0 } ->
-    totalMinutes = ((hours * 60 + minutes) % minutesPerDay + minutesPerDay) % minutesPerDay
+    hours24 = (hours % 24 + minutes // 60) % 24
+    minutes60 = minutes % 60
+    totalMinutes = ((hours24 * 60 + minutes60) % minutesPerDay + minutesPerDay) % minutesPerDay
     hh = totalMinutes // 60 |> Num.toU8
     mm = totalMinutes % 60 |> Num.toU8
     { hour: hh, minute: mm }
@@ -18,10 +20,10 @@ toStr = \{ hour, minute } ->
 
 add : Clock, { hours ? I64, minutes ? I64 }* -> Clock
 add = \{ hour, minute }, { hours ? 0, minutes ? 0 } ->
-    totalHours = Num.toI64 hour + hours
-    totalMinutes = Num.toI64 minute + minutes
+    totalHours = Num.toI64 hour + (hours % 24 + minutes // 60)
+    totalMinutes = Num.toI64 minute + minutes % 60
     create { hours: totalHours, minutes: totalMinutes }
 
 subtract : Clock, { hours ? I64, minutes ? I64 }* -> Clock
 subtract = \clock, { hours ? 0, minutes ? 0 } ->
-    clock |> add { hours: -hours, minutes: -minutes }
+    clock |> add { hours: -(hours % 24 + minutes // 60), minutes: -(minutes % 60) }

--- a/exercises/practice/clock/.meta/additional_tests.json
+++ b/exercises/practice/clock/.meta/additional_tests.json
@@ -1,0 +1,62 @@
+{
+  "cases": [
+    {
+      "description": "Can create a clock with max I64 values",
+      "property": "create",
+      "input": {
+        "hour": 9223372036854775807,
+        "minute": 9223372036854775807
+      },
+      "expected": "01:07"
+    },
+    {
+      "description": "Can create a clock with min I64 values",
+      "property": "create",
+      "input": {
+        "hour": -9223372036854775808,
+        "minute": -9223372036854775808
+      },
+      "expected": "21:52"
+    },
+    {
+      "description": "Can add max I64 values to a clock",
+      "property": "add",
+      "input": {
+        "hour": 23,
+        "minute": 59,
+        "value": 9223372036854775807
+      },
+      "expected": "18:06"
+    },
+    {
+      "description": "Can add min I64 values to a clock",
+      "property": "add",
+      "input": {
+        "hour": 23,
+        "minute": 59,
+        "value": -9223372036854775808
+      },
+      "expected": "05:51"
+    },
+    {
+      "description": "Can subtract max I64 values from a clock",
+      "property": "subtract",
+      "input": {
+        "hour": 23,
+        "minute": 59,
+        "value": 9223372036854775807
+      },
+      "expected": "05:52"
+    },
+    {
+      "description": "Can subtract min I64 values from a clock",
+      "property": "subtract",
+      "input": {
+        "hour": 23,
+        "minute": 59,
+        "value": -9223372036854775808
+      },
+      "expected": "18:07"
+    }
+  ]
+}

--- a/exercises/practice/clock/.meta/template.j2
+++ b/exercises/practice/clock/.meta/template.j2
@@ -4,13 +4,9 @@
 
 import {{ exercise | to_pascal }} exposing [create, add, subtract, toStr]
 
-{% for supercase in cases %}
-##
-## {{ supercase["description"] }}
-##
-
-{% for case in supercase["cases"] -%}
+{% macro test_case(case) %}
 # {{ case["description"] }}
+
 {%- if case["property"] == "create" %}
 expect
     clock = create {{ plugins.to_hours_minutes_record(case["input"]) }}
@@ -33,6 +29,22 @@ expect
 # this test case is not implemented yet. Perhaps you can give it a try?
 {%- endif %}
 
+{% endmacro %}
+
+{% for supercase in cases %}
+##
+## {{ supercase["description"] }}
+##
+
+{% for case in supercase["cases"] -%}
+{{ test_case(case) }}
 {% endfor %}
 {% endfor %}
 
+##
+## Extreme I64 values should not crash with overflow errors
+##
+
+{% for case in additional_cases -%}
+{{ test_case(case) }}
+{% endfor %}

--- a/exercises/practice/clock/clock-test.roc
+++ b/exercises/practice/clock/clock-test.roc
@@ -1,6 +1,6 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/clock/canonical-data.json
-# File last updated on 2024-09-11
+# File last updated on 2024-10-13
 app [main] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br",
 }
@@ -373,4 +373,50 @@ expect
     clock1 = create { hours: 24 }
     clock2 = create {}
     clock1 == clock2
+
+##
+## Extreme I64 values should not crash with overflow errors
+##
+
+# Can create a clock with max I64 values
+expect
+    clock = create { hours: 9223372036854775807, minutes: 9223372036854775807 }
+    result = clock |> toStr
+    expected = "01:07"
+    result == expected
+
+# Can create a clock with min I64 values
+expect
+    clock = create { hours: -9223372036854775808, minutes: -9223372036854775808 }
+    result = clock |> toStr
+    expected = "21:52"
+    result == expected
+
+# Can add max I64 values to a clock
+expect
+    clock = create { hours: 23, minutes: 59 }
+    result = clock |> add { minutes: 9223372036854775807 } |> toStr
+    expected = "18:06"
+    result == expected
+
+# Can add min I64 values to a clock
+expect
+    clock = create { hours: 23, minutes: 59 }
+    result = clock |> add { minutes: -9223372036854775808 } |> toStr
+    expected = "05:51"
+    result == expected
+
+# Can subtract max I64 values from a clock
+expect
+    clock = create { hours: 23, minutes: 59 }
+    result = clock |> subtract { minutes: 9223372036854775807 } |> toStr
+    expected = "05:52"
+    result == expected
+
+# Can subtract min I64 values from a clock
+expect
+    clock = create { hours: 23, minutes: 59 }
+    result = clock |> subtract { minutes: -9223372036854775808 } |> toStr
+    expected = "18:07"
+    result == expected
 


### PR DESCRIPTION
This PR adds tests that ensure that the implementation can handle the min and max I64 values.
This makes the exercise a bit harder, perhaps we should bump its difficulty to 3.

Another option would be to let the functions return `Result Str _` rather than `Str`, and just ensure that the tests for the min/max I64 values don't crash: we can simply make sure that the result for these test cases are either `Ok` with the correct value, or any `Err`. Wdyt?
