### PR TITLE
Upgrade isodate library

### DIFF
--- a/config/generator_macros.j2
+++ b/config/generator_macros.j2
@@ -24,7 +24,7 @@ app [main] {
     {% if name == "unicode" -%}
     unicode: "https://github.com/roc-lang/unicode/releases/download/0.1.2/vH5iqn04ShmqP-pNemgF773f86COePSqMWHzVGrAKNo.tar.br"
     {%- elif name == "isodate" -%}
-    isodate: "https://github.com/imclerran/roc-isodate/releases/download/v0.5.0/ptg0ElRLlIqsxMDZTTvQHgUSkNrUSymQaGwTfv0UEmk.tar.br"
+    isodate: "https://github.com/imclerran/roc-isodate/releases/download/v0.5.1/XHx5wx95nuICKpN8sxMwYnCme5oX_YFbJUL1s6D1feU.tar.br"
     {%- elif name == "json" -%}
     json: "https://github.com/lukewilliamboswell/roc-json/releases/download/0.10.2/FH4N0Sw-JSFXJfG3j54VEDPtXOoN-6I9v_IA8S18IGk.tar.br"
     {%- endif -%}

--- a/exercises/practice/gigasecond/gigasecond-test.roc
+++ b/exercises/practice/gigasecond/gigasecond-test.roc
@@ -1,9 +1,9 @@
 # These tests are auto-generated with test data from:
 # https://github.com/exercism/problem-specifications/tree/main/exercises/gigasecond/canonical-data.json
-# File last updated on 2024-08-27
+# File last updated on 2024-10-18
 app [main] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.15.0/SlwdbJ-3GR7uBWQo6zlmYWNYOxnvo8r6YABXD-45UOw.tar.br",
-    isodate: "https://github.com/imclerran/roc-isodate/releases/download/v0.5.0/ptg0ElRLlIqsxMDZTTvQHgUSkNrUSymQaGwTfv0UEmk.tar.br",
+    isodate: "https://github.com/imclerran/roc-isodate/releases/download/v0.5.1/XHx5wx95nuICKpN8sxMwYnCme5oX_YFbJUL1s6D1feU.tar.br",
 }
 
 main =


### PR DESCRIPTION
Upgrade the isodate library to 0.5.1, which supports finding the weekdays and day of month of a given date. This will come in handy for the `meetup` exercise.
Note: only merge this PR once the roc-test-runner's cache includes this upgraded library (i.e., when https://github.com/exercism/roc-test-runner/pull/16 is merged and deployed).

This upgrade does not affect the existing user solutions, so we must include `[no important files changed]` in the merge-commit message.