### PR TITLE
Add `flower-field`, deprecating `minesweeper`

### DIFF
--- a/config.json
+++ b/config.json
@@ -740,6 +740,14 @@
         "difficulty": 6
       },
       {
+        "slug": "flower-field",
+        "name": "Flower Field",
+        "uuid": "3d515ca6-aa26-4e4f-a92d-8381ef6d3809",
+        "practices": [],
+        "prerequisites": [],
+        "difficulty": 6
+      },
+      {
         "slug": "go-counting",
         "name": "Go Counting",
         "uuid": "8c81bf5c-5188-4e1b-9814-1f0f0fcdeec2",
@@ -777,7 +785,8 @@
         "uuid": "8d5ea690-9d52-4d0a-a59e-aeec1a03cac7",
         "practices": [],
         "prerequisites": [],
-        "difficulty": 6
+        "difficulty": 6,
+        "status": "deprecated"
       },
       {
         "slug": "palindrome-products",

--- a/exercises/practice/flower-field/.docs/instructions.md
+++ b/exercises/practice/flower-field/.docs/instructions.md
@@ -1,0 +1,26 @@
+# Instructions
+
+Your task is to add flower counts to empty squares in a completed Flower Field garden.
+The garden itself is a rectangle board composed of squares that are either empty (`' '`) or a flower (`'*'`).
+
+For each empty square, count the number of flowers adjacent to it (horizontally, vertically, diagonally).
+If the empty square has no adjacent flowers, leave it empty.
+Otherwise replace it with the count of adjacent flowers.
+
+For example, you may receive a 5 x 4 board like this (empty spaces are represented here with the '·' character for display on screen):
+
+```text
+·*·*·
+··*··
+··*··
+·····
+```
+
+Which your code should transform into this:
+
+```text
+1*3*1
+13*31
+·2*2·
+·111·
+```

--- a/exercises/practice/flower-field/.docs/introduction.md
+++ b/exercises/practice/flower-field/.docs/introduction.md
@@ -1,0 +1,7 @@
+# Introduction
+
+[Flower Field][history] is a compassionate reimagining of the popular game Minesweeper.
+The object of the game is to find all the flowers in the garden using numeric hints that indicate how many flowers are directly adjacent (horizontally, vertically, diagonally) to a square.
+"Flower Field" shipped in regional versions of Microsoft Windows in Italy, Germany, South Korea, Japan and Taiwan.
+
+[history]: https://web.archive.org/web/20020409051321fw_/http://rcm.usr.dsi.unimi.it/rcmweb/fnm/

--- a/exercises/practice/flower-field/.meta/Example.roc
+++ b/exercises/practice/flower-field/.meta/Example.roc
@@ -1,0 +1,56 @@
+module [annotate]
+
+is_flower : List (List U8), I64, I64 -> Result Bool [OutOfBounds]
+is_flower = |rows, nx, ny|
+    x = Num.to_u64_checked(nx)?
+    y = Num.to_u64_checked(ny)?
+    rows
+    |> List.get(y)?
+    |> List.get(x)?
+    |> Bool.is_eq('*')
+    |> Ok
+
+count_neighbors : List (List U8), U64, U64 -> Num *
+count_neighbors = |rows, x, y|
+    [-1, 0, 1]
+    |> List.map(
+        |dy|
+            [-1, 0, 1]
+            |> List.map(
+                |dx|
+                    when is_flower(rows, (Num.to_i64(x) + dx), (Num.to_i64(y) + dy)) is
+                        Ok(flower) -> if flower then 1 else 0
+                        Err(OutOfBounds) -> 0,
+            )
+            |> List.sum,
+    )
+    |> List.sum
+
+annotate : Str -> Str
+annotate = |garden|
+    rows = garden |> Str.to_utf8 |> List.split_on('\n')
+    annotated =
+        rows
+        |> List.map_with_index(
+            |row, y|
+                row
+                |> List.map_with_index(
+                    |cell, x|
+                        if cell == '*' then
+                            '*'
+                        else
+                            when count_neighbors(rows, x, y) is
+                                0 -> ' '
+                                n -> '0' + n,
+                )
+                |> Str.from_utf8,
+        )
+
+    annotated
+    |> List.map(
+        |maybe_row|
+            when maybe_row is
+                Ok(row) -> row
+                Err(_) -> crash("Unreachable"),
+    ) # fromUtf8 cannot fail in the code above
+    |> Str.join_with("\n")

--- a/exercises/practice/flower-field/.meta/config.json
+++ b/exercises/practice/flower-field/.meta/config.json
@@ -1,0 +1,20 @@
+{
+  "authors": [
+    "ageron"
+  ],
+  "contributors": [
+    "BNAndras"
+  ],
+  "files": {
+    "solution": [
+      "FlowerField.roc"
+    ],
+    "test": [
+      "flower-field-test.roc"
+    ],
+    "example": [
+      ".meta/Example.roc"
+    ]
+  },
+  "blurb": "Mark all the flowers in a garden."
+}

--- a/exercises/practice/flower-field/.meta/template.j2
+++ b/exercises/practice/flower-field/.meta/template.j2
@@ -7,9 +7,9 @@ import {{ exercise | to_pascal }} exposing [{{ cases[0]["property"] | to_snake }
 {% for case in cases -%}
 # {{ case["description"] }}
 expect
-    garden = {{ case["input"]["garden"] | to_roc_multiline_string | replace(" ", "·") | indent(8) }} |> Str.replaceEach "·" " "
+    garden = {{ case["input"]["garden"] | to_roc_multiline_string | replace(" ", "·") | indent(8) }} |> Str.replace_each "·" " "
     result = {{ case["property"] | to_snake }} garden
-    expected = {{ case["expected"] | to_roc_multiline_string | replace(" ", "·") | indent(8) }}  |> Str.replaceEach "·" " "
+    expected = {{ case["expected"] | to_roc_multiline_string | replace(" ", "·") | indent(8) }}  |> Str.replace_each "·" " "
     result == expected
 
 {% endfor %}

--- a/exercises/practice/flower-field/.meta/template.j2
+++ b/exercises/practice/flower-field/.meta/template.j2
@@ -1,0 +1,15 @@
+{%- import "generator_macros.j2" as macros with context -%}
+{{ macros.canonical_ref() }}
+{{ macros.header() }}
+
+import {{ exercise | to_pascal }} exposing [{{ cases[0]["property"] | to_snake }}]
+
+{% for case in cases -%}
+# {{ case["description"] }}
+expect
+    garden = {{ case["input"]["garden"] | to_roc_multiline_string | replace(" ", "·") | indent(8) }} |> Str.replaceEach "·" " "
+    result = {{ case["property"] | to_snake }} garden
+    expected = {{ case["expected"] | to_roc_multiline_string | replace(" ", "·") | indent(8) }}  |> Str.replaceEach "·" " "
+    result == expected
+
+{% endfor %}

--- a/exercises/practice/flower-field/.meta/tests.toml
+++ b/exercises/practice/flower-field/.meta/tests.toml
@@ -1,0 +1,46 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[237ff487-467a-47e1-9b01-8a891844f86c]
+description = "no rows"
+
+[4b4134ec-e20f-439c-a295-664c38950ba1]
+description = "no columns"
+
+[d774d054-bbad-4867-88ae-069cbd1c4f92]
+description = "no flowers"
+
+[225176a0-725e-43cd-aa13-9dced501f16e]
+description = "garden full of flowers"
+
+[3f345495-f1a5-4132-8411-74bd7ca08c49]
+description = "flower surrounded by spaces"
+
+[6cb04070-4199-4ef7-a6fa-92f68c660fca]
+description = "space surrounded by flowers"
+
+[272d2306-9f62-44fe-8ab5-6b0f43a26338]
+description = "horizontal line"
+
+[c6f0a4b2-58d0-4bf6-ad8d-ccf4144f1f8e]
+description = "horizontal line, flowers at edges"
+
+[a54e84b7-3b25-44a8-b8cf-1753c8bb4cf5]
+description = "vertical line"
+
+[b40f42f5-dec5-4abc-b167-3f08195189c1]
+description = "vertical line, flowers at edges"
+
+[58674965-7b42-4818-b930-0215062d543c]
+description = "cross"
+
+[dd9d4ca8-9e68-4f78-a677-a2a70fd7a7b8]
+description = "large garden"

--- a/exercises/practice/flower-field/FlowerField.roc
+++ b/exercises/practice/flower-field/FlowerField.roc
@@ -1,0 +1,5 @@
+module [annotate]
+
+annotate : Str -> Str
+annotate = |garden|
+    crash("Please implement the 'annotate' function")

--- a/exercises/practice/flower-field/flower-field-test.roc
+++ b/exercises/practice/flower-field/flower-field-test.roc
@@ -14,16 +14,16 @@ import FlowerField exposing [annotate]
 
 # no rows
 expect
-    garden = "" |> Str.replaceEach "·" " "
+    garden = "" |> Str.replace_each "·" " "
     result = annotate garden
-    expected = "" |> Str.replaceEach "·" " "
+    expected = "" |> Str.replace_each "·" " "
     result == expected
 
 # no columns
 expect
-    garden = "" |> Str.replaceEach "·" " "
+    garden = "" |> Str.replace_each "·" " "
     result = annotate garden
-    expected = "" |> Str.replaceEach "·" " "
+    expected = "" |> Str.replace_each "·" " "
     result == expected
 
 # no flowers
@@ -34,7 +34,7 @@ expect
         ···
         ···
         """
-        |> Str.replaceEach "·" " "
+        |> Str.replace_each "·" " "
     result = annotate garden
     expected =
         """
@@ -42,7 +42,7 @@ expect
         ···
         ···
         """
-        |> Str.replaceEach "·" " "
+        |> Str.replace_each "·" " "
     result == expected
 
 # garden full of flowers
@@ -53,7 +53,7 @@ expect
         ***
         ***
         """
-        |> Str.replaceEach "·" " "
+        |> Str.replace_each "·" " "
     result = annotate garden
     expected =
         """
@@ -61,7 +61,7 @@ expect
         ***
         ***
         """
-        |> Str.replaceEach "·" " "
+        |> Str.replace_each "·" " "
     result == expected
 
 # flower surrounded by spaces
@@ -72,7 +72,7 @@ expect
         ·*·
         ···
         """
-        |> Str.replaceEach "·" " "
+        |> Str.replace_each "·" " "
     result = annotate garden
     expected =
         """
@@ -80,7 +80,7 @@ expect
         1*1
         111
         """
-        |> Str.replaceEach "·" " "
+        |> Str.replace_each "·" " "
     result == expected
 
 # space surrounded by flowers
@@ -91,7 +91,7 @@ expect
         *·*
         ***
         """
-        |> Str.replaceEach "·" " "
+        |> Str.replace_each "·" " "
     result = annotate garden
     expected =
         """
@@ -99,21 +99,21 @@ expect
         *8*
         ***
         """
-        |> Str.replaceEach "·" " "
+        |> Str.replace_each "·" " "
     result == expected
 
 # horizontal line
 expect
-    garden = "·*·*·" |> Str.replaceEach "·" " "
+    garden = "·*·*·" |> Str.replace_each "·" " "
     result = annotate garden
-    expected = "1*2*1" |> Str.replaceEach "·" " "
+    expected = "1*2*1" |> Str.replace_each "·" " "
     result == expected
 
 # horizontal line, flowers at edges
 expect
-    garden = "*···*" |> Str.replaceEach "·" " "
+    garden = "*···*" |> Str.replace_each "·" " "
     result = annotate garden
-    expected = "*1·1*" |> Str.replaceEach "·" " "
+    expected = "*1·1*" |> Str.replace_each "·" " "
     result == expected
 
 # vertical line
@@ -126,7 +126,7 @@ expect
         *
         ·
         """
-        |> Str.replaceEach "·" " "
+        |> Str.replace_each "·" " "
     result = annotate garden
     expected =
         """
@@ -136,7 +136,7 @@ expect
         *
         1
         """
-        |> Str.replaceEach "·" " "
+        |> Str.replace_each "·" " "
     result == expected
 
 # vertical line, flowers at edges
@@ -149,7 +149,7 @@ expect
         ·
         *
         """
-        |> Str.replaceEach "·" " "
+        |> Str.replace_each "·" " "
     result = annotate garden
     expected =
         """
@@ -159,7 +159,7 @@ expect
         1
         *
         """
-        |> Str.replaceEach "·" " "
+        |> Str.replace_each "·" " "
     result == expected
 
 # cross
@@ -172,7 +172,7 @@ expect
         ··*··
         ··*··
         """
-        |> Str.replaceEach "·" " "
+        |> Str.replace_each "·" " "
     result = annotate garden
     expected =
         """
@@ -182,7 +182,7 @@ expect
         25*52
         ·2*2·
         """
-        |> Str.replaceEach "·" " "
+        |> Str.replace_each "·" " "
     result == expected
 
 # large garden
@@ -196,7 +196,7 @@ expect
         ·*··*·
         ······
         """
-        |> Str.replaceEach "·" " "
+        |> Str.replace_each "·" " "
     result = annotate garden
     expected =
         """
@@ -207,6 +207,6 @@ expect
         1*22*2
         111111
         """
-        |> Str.replaceEach "·" " "
+        |> Str.replace_each "·" " "
     result == expected
 

--- a/exercises/practice/flower-field/flower-field-test.roc
+++ b/exercises/practice/flower-field/flower-field-test.roc
@@ -1,0 +1,212 @@
+# These tests are auto-generated with test data from:
+# https://github.com/exercism/problem-specifications/tree/main/exercises/flower-field/canonical-data.json
+# File last updated on 2025-07-02
+app [main!] {
+    pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.19.0/Hj-J_zxz7V9YurCSTFcFdu6cQJie4guzsPMUi5kBYUk.tar.br",
+}
+
+import pf.Stdout
+
+main! = |_args|
+    Stdout.line! ""
+
+import FlowerField exposing [annotate]
+
+# no rows
+expect
+    garden = "" |> Str.replaceEach "·" " "
+    result = annotate garden
+    expected = "" |> Str.replaceEach "·" " "
+    result == expected
+
+# no columns
+expect
+    garden = "" |> Str.replaceEach "·" " "
+    result = annotate garden
+    expected = "" |> Str.replaceEach "·" " "
+    result == expected
+
+# no flowers
+expect
+    garden =
+        """
+        ···
+        ···
+        ···
+        """
+        |> Str.replaceEach "·" " "
+    result = annotate garden
+    expected =
+        """
+        ···
+        ···
+        ···
+        """
+        |> Str.replaceEach "·" " "
+    result == expected
+
+# garden full of flowers
+expect
+    garden =
+        """
+        ***
+        ***
+        ***
+        """
+        |> Str.replaceEach "·" " "
+    result = annotate garden
+    expected =
+        """
+        ***
+        ***
+        ***
+        """
+        |> Str.replaceEach "·" " "
+    result == expected
+
+# flower surrounded by spaces
+expect
+    garden =
+        """
+        ···
+        ·*·
+        ···
+        """
+        |> Str.replaceEach "·" " "
+    result = annotate garden
+    expected =
+        """
+        111
+        1*1
+        111
+        """
+        |> Str.replaceEach "·" " "
+    result == expected
+
+# space surrounded by flowers
+expect
+    garden =
+        """
+        ***
+        *·*
+        ***
+        """
+        |> Str.replaceEach "·" " "
+    result = annotate garden
+    expected =
+        """
+        ***
+        *8*
+        ***
+        """
+        |> Str.replaceEach "·" " "
+    result == expected
+
+# horizontal line
+expect
+    garden = "·*·*·" |> Str.replaceEach "·" " "
+    result = annotate garden
+    expected = "1*2*1" |> Str.replaceEach "·" " "
+    result == expected
+
+# horizontal line, flowers at edges
+expect
+    garden = "*···*" |> Str.replaceEach "·" " "
+    result = annotate garden
+    expected = "*1·1*" |> Str.replaceEach "·" " "
+    result == expected
+
+# vertical line
+expect
+    garden =
+        """
+        ·
+        *
+        ·
+        *
+        ·
+        """
+        |> Str.replaceEach "·" " "
+    result = annotate garden
+    expected =
+        """
+        1
+        *
+        2
+        *
+        1
+        """
+        |> Str.replaceEach "·" " "
+    result == expected
+
+# vertical line, flowers at edges
+expect
+    garden =
+        """
+        *
+        ·
+        ·
+        ·
+        *
+        """
+        |> Str.replaceEach "·" " "
+    result = annotate garden
+    expected =
+        """
+        *
+        1
+        ·
+        1
+        *
+        """
+        |> Str.replaceEach "·" " "
+    result == expected
+
+# cross
+expect
+    garden =
+        """
+        ··*··
+        ··*··
+        *****
+        ··*··
+        ··*··
+        """
+        |> Str.replaceEach "·" " "
+    result = annotate garden
+    expected =
+        """
+        ·2*2·
+        25*52
+        *****
+        25*52
+        ·2*2·
+        """
+        |> Str.replaceEach "·" " "
+    result == expected
+
+# large garden
+expect
+    garden =
+        """
+        ·*··*·
+        ··*···
+        ····*·
+        ···*·*
+        ·*··*·
+        ······
+        """
+        |> Str.replaceEach "·" " "
+    result = annotate garden
+    expected =
+        """
+        1*22*1
+        12*322
+        ·123*2
+        112*4*
+        1*22*2
+        111111
+        """
+        |> Str.replaceEach "·" " "
+    result == expected
+


### PR DESCRIPTION
This PR adds Flower Field, deprecating Minesweeper. See https://forum.exercism.org/t/suggestion-deprecate-minesweeper-for-flower-field/17967


I'm having some trouble with the template. I'm using the Minesweeper template with some very minor alterations. However `roc test` fails because `Str.replaceEach` isn't valid although the Minesweeper tests use `Str.replace_each`. Is this a version mismatch? Locally, I'm on `roc nightly pre-release, built from commit c47a8e9 on Sa 22 Mär 2025 09:02:05 UTC`