### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/error-handling/.docs/instructions.append.md
+++ b/exercises/practice/error-handling/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 You are building a tiny web server that queries an even tinier user database. Sounds easy, but in the real world many things can (and often do) go wrong:
 
 - the connection may be insecure: the URL must start with `"https://"`

--- a/exercises/practice/hello-world/.docs/instructions.append.md
+++ b/exercises/practice/hello-world/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 The file to edit is named `HelloWorld.roc`.
 
 If you are using the command line, run the test suite using `roc test hello-world-test.roc`

--- a/exercises/practice/list-ops/.docs/instructions.append.md
+++ b/exercises/practice/list-ops/.docs/instructions.append.md
@@ -1,18 +1,16 @@
-# Wait, It's Impossible!
+# Instructions append
 
-Implementing these list operations without using _any_ built-in function is
-virtually impossible in Roc, because you need a way to append or prepend
-elements to a list. In other languages you might use operators such as `:`
-in Haskell or `+=` in Python, but in Roc you have to use the
-[`List` functions](https://www.roc-lang.org/builtins/List).
+## Wait, It's Impossible!
 
-So for this exercise you're allowed to use `List.append` (but avoid using any
-other built-in function).
+Implementing these list operations without using _any_ built-in function is virtually impossible in Roc, because you need a way to append or prepend elements to a list.
+In other languages you might use operators such as `:` in Haskell or `+=` in Python, but in Roc you have to use the [`List` functions](https://www.roc-lang.org/builtins/List).
+
+So for this exercise you're allowed to use `List.append` (but avoid using any other built-in function).
 
 Many functional programming languages use linked lists as the primary collection type.
-It is efficient to prepend an element or pop the first element from a linked list, so in those languages, you would implement list operations
-using `List.prepend`. In Roc however, a `List` is an array (a contiguous chunk of bytes). Arrays have different
-properties than linked lists like the ability to efficiently access elements by index and append new elements.
+It is efficient to prepend an element or pop the first element from a linked list, so in those languages, you would implement list operations using `List.prepend`.
+In Roc however, a `List` is an array (a contiguous chunk of bytes).
+Arrays have different properties than linked lists like the ability to efficiently access elements by index and append new elements.
 Because of this, in Roc we use `List.append` often and rarely use `List.prepend`.
 
 Hint: try using:

--- a/exercises/practice/queen-attack/.docs/instructions.append.md
+++ b/exercises/practice/queen-attack/.docs/instructions.append.md
@@ -1,27 +1,22 @@
 # Instructions append
 
-In Chess, rows are called "ranks", and columns are called "files". Ranks range
-from 1 to 8, while files range from A to H.
+## Implementation
 
-In this exercise, `Square` is an opaque type which represents a square on a
-chessboard. It uses 0-indexed `row` & `column` fields internally, and it
-guarantees that they are always valid (i.e., from 0 to 7).
+In Chess, rows are called "ranks", and columns are called "files".
+Ranks range from 1 to 8, while files range from A to H.
 
-The `create` function takes a `Str` as input, representing a valid square on
-the chessboard using the official notation, such as `"C5"`. The `create`
-function must parse this `Str`, verify that it represents a valid square, and if
-so it must return a `Square` value containing the appropriate `row` and `column`
-fields. Rank 1 corresponds to row 0, and rank 8 corresponds to row 7. For
-example, `create "C5"` must return `@Square { row : 2, column : 3 }`.
+In this exercise, `Square` is an opaque type which represents a square on a chessboard.
+It uses 0-indexed `row` & `column` fields internally, and it guarantees that they are always valid (i.e., from 0 to 7).
 
-The `QueenAttack` module also exposes handy `rank` & `file` functions. In the
-example above, `rank` must return the integer `5`, and `file` must return the
-character `'C'`.
+The `create` function takes a `Str` as input, representing a valid square on the chessboard using the official notation, such as `"C5"`.
+The `create` function must parse this `Str`, verify that it represents a valid square, and if so it must return a `Square` value containing the appropriate `row` and `column` fields.
+Rank 1 corresponds to row 0, and rank 8 corresponds to row 7.
+For example, `create "C5"` must return `@Square { row : 2, column : 3 }`.
 
-Lastly, the `queen_can_attack` function takes two different `Square` values and
-checks whether or not queens placed on these squares can attack each other.
+The `QueenAttack` module also exposes handy `rank` & `file` functions.
+In the example above, `rank` must return the integer `5`, and `file` must return the character `'C'`.
 
-Take-away: opaque types such as `Square` are great when you want to offer some
-guarantees, such as the fact that `row` and `column` are always between 0 and 7.
-Opaque types also hide implementation details from the users, which makes the
-API cleaner.
+Lastly, the `queen_can_attack` function takes two different `Square` values and checks whether or not queens placed on these squares can attack each other.
+
+Take-away: opaque types such as `Square` are great when you want to offer some guarantees, such as the fact that `row` and `column` are always between 0 and 7.
+Opaque types also hide implementation details from the users, which makes the API cleaner.

--- a/exercises/practice/square-root/.docs/instructions.append.md
+++ b/exercises/practice/square-root/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions append
 
+## Implementation
+
 This problem can be solved easily using Roc's built-in `Num` module, including the [`Num.sqrt`][sqrt] function.
 
 However, we'd like you to consider the challenge of solving this exercise without using built-ins or modules.


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.