### PR TITLE
Reject user_id in scientific format, as per the tests

### DIFF
--- a/exercises/practice/error-handling/.meta/Example.roc
+++ b/exercises/practice/error-handling/.meta/Example.roc
@@ -20,7 +20,11 @@ ErrorHandling :: {}.{
 	parse_user_id : Str -> Try(UserId, [InvalidUserId(Str), ..])
 	parse_user_id = |path| {
 		user_id_str = path.drop_prefix("/users/")
-		(user_id_str |> U64.from_str).map_err(|_| InvalidUserId(user_id_str))
+		if user_id_str.contains("e") or user_id_str.contains("E") {
+			Err(InvalidUserId(user_id_str))
+		} else {
+			(user_id_str |> U64.from_str).map_err(|_| InvalidUserId(user_id_str))
+		}
 	}
 
 	# # Takes a URL and returns the page content, or the appropriate error


### PR DESCRIPTION
The latest Roc compiler now supports `U64.from_str("1e03")`. This breaks one of the tests in the `error-handling` exercise, so this PR explicitly rejects user IDs containing the letter `e` or `E`.