### PR TITLE
Update to the Unicode 3.0.0 library

### DIFF
--- a/config/generator_macros.j2
+++ b/config/generator_macros.j2
@@ -22,7 +22,7 @@ app [main!] {
     pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.21.0/4rAQg8kUYZ3Vksr4qMQHpaFYNiHSn9GgS7gVxghd1XYV.tar.zst"
 {%- for name in imports -%},
     {% if name == "unicode" -%}
-    unicode: "https://github.com/roc-lang/unicode/releases/download/2.0.0/9ZvqNzsNkpqFmGTeATAY3BNBD7mP41jqZx2w2N19tBvh.tar.zst",
+    unicode: "https://github.com/roc-lang/unicode/releases/download/3.0.0/ACj5ceJnEY6vaejuQArN1naVzcxeThATZrKYYgzJCZJ5.tar.zst",
     {%- elif name == "isodate" -%}
     isodate: "https://github.com/ageron/roc-isodate/releases/download/0.8.0/B2h6tefXQtEz9VG6QukLDBoGXhRtwGLj9sZHDEJaTHkS.tar.zst",
     {%- elif name == "parser" -%}

--- a/exercises/practice/anagram/.meta/Example.roc
+++ b/exercises/practice/anagram/.meta/Example.roc
@@ -64,7 +64,7 @@ compare_graphemes = |g1, g2| {
 }
 
 sorted_graphemes = |word| {
-	graphemes = Grapheme.split(word)?
+	graphemes = Grapheme.owned(word)
 	graphemes.sort_with(compare_graphemes) |> Ok
 }
 

--- a/exercises/practice/anagram/anagram-test.roc
+++ b/exercises/practice/anagram/anagram-test.roc
@@ -3,7 +3,7 @@
 # File last updated on 2026-08-01
 app [main!] {
 	pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.21.0/4rAQg8kUYZ3Vksr4qMQHpaFYNiHSn9GgS7gVxghd1XYV.tar.zst",
-	unicode: "https://github.com/roc-lang/unicode/releases/download/2.0.0/9ZvqNzsNkpqFmGTeATAY3BNBD7mP41jqZx2w2N19tBvh.tar.zst",
+	unicode: "https://github.com/roc-lang/unicode/releases/download/3.0.0/ACj5ceJnEY6vaejuQArN1naVzcxeThATZrKYYgzJCZJ5.tar.zst",
 }
 
 import Anagram exposing [find_anagrams]

--- a/exercises/practice/micro-blog/.meta/Example.roc
+++ b/exercises/practice/micro-blog/.meta/Example.roc
@@ -12,7 +12,8 @@ MicroBlog :: {}.{
 
 	truncate : Str -> Try(Str, GraphemeErrors)
 	truncate = |input| {
-		(input |> Grapheme.split)?
+		input
+			|> Grapheme.owned
 			.take_first(5)
 			|> Str.join_with("")
 			|> Ok

--- a/exercises/practice/micro-blog/micro-blog-test.roc
+++ b/exercises/practice/micro-blog/micro-blog-test.roc
@@ -3,7 +3,7 @@
 # File last updated on 2026-08-01
 app [main!] {
 	pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.21.0/4rAQg8kUYZ3Vksr4qMQHpaFYNiHSn9GgS7gVxghd1XYV.tar.zst",
-	unicode: "https://github.com/roc-lang/unicode/releases/download/2.0.0/9ZvqNzsNkpqFmGTeATAY3BNBD7mP41jqZx2w2N19tBvh.tar.zst",
+	unicode: "https://github.com/roc-lang/unicode/releases/download/3.0.0/ACj5ceJnEY6vaejuQArN1naVzcxeThATZrKYYgzJCZJ5.tar.zst",
 }
 
 import MicroBlog exposing [truncate]

--- a/exercises/practice/reverse-string/.meta/Example.roc
+++ b/exercises/practice/reverse-string/.meta/Example.roc
@@ -1,6 +1,7 @@
 
 
 import unicode.Grapheme
+
 ReverseString :: {}.{
 
 	## This function reverses the input string, e.g., "café" -> "éfac".
@@ -14,12 +15,7 @@ ReverseString :: {}.{
 	## Luckily, we've added it for you in reverse-string-test.roc. Take a look!
 	reverse : Str -> Str
 	reverse = |string| {
-		match Grapheme.split(string) {
-			Ok(graphemes) => graphemes.rev() |> Str.join_with("")
-			Err(_) => {
-				crash "Unexpected error: could not split the string into graphemes"
-			}
-		}
+		Grapheme.owned(string).rev() |> Str.join_with("")
 	}
 
 	## This function reverses the input string, e.g., "hello" -> "olleh". It is

--- a/exercises/practice/reverse-string/reverse-string-test.roc
+++ b/exercises/practice/reverse-string/reverse-string-test.roc
@@ -3,7 +3,7 @@
 # File last updated on 2026-08-01
 app [main!] {
 	pf: platform "https://github.com/roc-lang/basic-cli/releases/download/0.21.0/4rAQg8kUYZ3Vksr4qMQHpaFYNiHSn9GgS7gVxghd1XYV.tar.zst",
-	unicode: "https://github.com/roc-lang/unicode/releases/download/2.0.0/9ZvqNzsNkpqFmGTeATAY3BNBD7mP41jqZx2w2N19tBvh.tar.zst",
+	unicode: "https://github.com/roc-lang/unicode/releases/download/3.0.0/ACj5ceJnEY6vaejuQArN1naVzcxeThATZrKYYgzJCZJ5.tar.zst",
 }
 
 import ReverseString exposing [reverse]


### PR DESCRIPTION
This PR migrates the Exercism exercises to the new Unicode 3.0.0 library. It only required three changes:

* updating the import URL
* replacing `Grapheme.split` with `Grapheme.owned`
* the new function returns a `List(Str)` instead of a `Try(List(Str), _)` so I removed some error checking.

